### PR TITLE
[dlflib][trivial] Remove unnecessary inlines

### DIFF
--- a/software/dlflib/include/dlflib/datastream/abstract_stream.h
+++ b/software/dlflib/include/dlflib/datastream/abstract_stream.h
@@ -46,19 +46,19 @@ class AbstractStream {
 
   virtual dlf_stream_type_e type() = 0;
 
-  inline size_t dataSize() { return src_.dataSize; }
+  size_t dataSize() { return src_.dataSize; }
 
-  inline const uint8_t* dataSource() { return src_.data; }
+  const uint8_t* dataSource() { return src_.data; }
 
-  inline const char* typeStructure() { return src_.typeStructure; }
+  const char* typeStructure() { return src_.typeStructure; }
 
-  inline size_t typeHash() { return src_.typeHash; }
+  size_t typeHash() { return src_.typeHash; }
 
-  inline const char* notes() { return notes_ != nullptr ? notes_ : "N/A"; }
+  const char* notes() { return notes_ != nullptr ? notes_ : "N/A"; }
 
-  inline const char* id() { return id_.c_str(); }
+  const char* id() { return id_.c_str(); }
 
-  inline SemaphoreHandle_t mutex() const { return mutex_; }
+  SemaphoreHandle_t mutex() const { return mutex_; }
 
  protected:
   AbstractStream(Encodable& dat, String id, const char* notes,

--- a/software/dlflib/include/dlflib/datastream/event_stream_handle.h
+++ b/software/dlflib/include/dlflib/datastream/event_stream_handle.h
@@ -16,7 +16,7 @@ class EventStreamHandle : public AbstractStreamHandle {
   size_t encodeInto(StreamBufferHandle_t buf, dlf_tick_t tick);
 
  private:
-  inline size_t currentHash();
+  size_t currentHash();
 
   size_t hash_ = 0;
 };

--- a/software/dlflib/include/dlflib/dlf_logger.h
+++ b/software/dlflib/include/dlflib/dlf_logger.h
@@ -15,25 +15,25 @@
 #include "dlflib/dlf_run.h"
 #include "dlflib/dlf_types.h"
 
-#define POLL(type_name)                                                       \
-  CSCLogger& poll(                                                            \
-      type_name& value, String id, std::chrono::microseconds sampleInterval,  \
-      std::chrono::microseconds phase = std::chrono::microseconds::zero(),    \
-      const char* notes = nullptr, SemaphoreHandle_t mutex = NULL) {          \
-    return pollInternal(Encodable(value, #type_name), id, sampleInterval,     \
-                        phase, notes, mutex);                                 \
-  }                                                                           \
-  inline CSCLogger& poll(type_name& value, String id,                         \
-                         std::chrono::microseconds sampleInterval,            \
-                         const char* notes, SemaphoreHandle_t mutex = NULL) { \
-    return pollInternal(Encodable(value, #type_name), id, sampleInterval,     \
-                        std::chrono::microseconds::zero(), notes, mutex);     \
-  }                                                                           \
-  inline CSCLogger& poll(type_name& value, String id,                         \
-                         std::chrono::microseconds sampleInterval,            \
-                         SemaphoreHandle_t mutex) {                           \
-    return pollInternal(Encodable(value, #type_name), id, sampleInterval,     \
-                        std::chrono::microseconds::zero(), nullptr, mutex);   \
+#define POLL(type_name)                                                        \
+  CSCLogger& poll(                                                             \
+      type_name& value, String id, std::chrono::microseconds sampleInterval,   \
+      std::chrono::microseconds phase = std::chrono::microseconds::zero(),     \
+      const char* notes = nullptr, SemaphoreHandle_t mutex = NULL) {           \
+    return pollInternal(Encodable(value, #type_name), id, sampleInterval,      \
+                        phase, notes, mutex);                                  \
+  }                                                                            \
+  CSCLogger& poll(type_name& value, String id,                                 \
+                  std::chrono::microseconds sampleInterval, const char* notes, \
+                  SemaphoreHandle_t mutex = NULL) {                            \
+    return pollInternal(Encodable(value, #type_name), id, sampleInterval,      \
+                        std::chrono::microseconds::zero(), notes, mutex);      \
+  }                                                                            \
+  CSCLogger& poll(type_name& value, String id,                                 \
+                  std::chrono::microseconds sampleInterval,                    \
+                  SemaphoreHandle_t mutex) {                                   \
+    return pollInternal(Encodable(value, #type_name), id, sampleInterval,      \
+                        std::chrono::microseconds::zero(), nullptr, mutex);    \
   }
 
 #define WATCH(type_name)                                                     \

--- a/software/dlflib/src/datastream/event_stream_handle.cpp
+++ b/software/dlflib/src/datastream/event_stream_handle.cpp
@@ -7,7 +7,7 @@ namespace dlf::datastream {
 EventStreamHandle::EventStreamHandle(EventStream* stream, dlf_stream_idx_t idx)
     : AbstractStreamHandle(stream, idx) {}
 
-inline size_t EventStreamHandle::currentHash() {
+size_t EventStreamHandle::currentHash() {
   return fnv_32_buf(stream->dataSource(), stream->dataSize(), FNV1_32_INIT);
 }
 


### PR DESCRIPTION
`inline` is required for free functions defined in header files, but implicit and redundant for class methods.
Since we had a mishmash, make it consistent (remove `inline` from class methods)