### PR TITLE
[dlflib] Implement partial run upload

### DIFF
--- a/software/data-visualizer/tsconfig.json
+++ b/software/data-visualizer/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/software/dlflib/include/dlflib/components/uploader_component.h
+++ b/software/dlflib/include/dlflib/components/uploader_component.h
@@ -11,8 +11,13 @@ namespace dlf::components {
 class UploaderComponent : public DlfComponent {
  public:
   struct Options {
+    // Delete the run data from the SD card after uploading
     bool deleteAfterUpload = false;
+    // Adds a marker file to the run directory on the SD card after uploading
     bool markAfterUpload = true;
+    // Attempts to upload the active runs' data at a regular interval. <= 0
+    // disables partial run uploads.
+    int partialRunUploadIntervalSecs = 0;
   };
   UploaderComponent(fs::FS& fs, const String& fsDir, const String& endpoint,
                     const String& deviceUid, const Options& options);
@@ -29,6 +34,7 @@ class UploaderComponent : public DlfComponent {
   };
 
   static void syncTask(void* arg);
+  static void partialRunUploadTask(void* arg);
 
   // https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/examples/WiFiClientEvents/WiFiClientEvents.ino
   void onWifiDisconnected(arduino_event_id_t event, arduino_event_info_t info);

--- a/software/dlflib/include/dlflib/dlf_logfile.h
+++ b/software/dlflib/include/dlflib/dlf_logfile.h
@@ -33,13 +33,29 @@ class LogFile {
   /**
    * Samples data. Intended to be externally called at the tick interval.
    * Called by the Run class to trigger a sample.
+   * @param tick The tick to sample data at
    */
   void sample(dlf_tick_t tick);
 
   /**
-   * Flushes and closes this logfile
+   * Flushes and closes this logfile.
    */
   void close();
+
+  /**
+   * Force a manual flush on the logfile.
+   */
+  void flush();
+
+  /**
+   * Lock the file mutex
+   */
+  void lock();
+
+  /**
+   * Release the file mutex
+   */
+  void unlock();
 
  private:
   /**
@@ -61,8 +77,6 @@ class LogFile {
    * buffers
    */
   void closeFile();
-
-  void flush();
 
   /**
    * @brief Data stream handles logged by this logfile

--- a/software/dlflib/include/dlflib/dlf_logger.h
+++ b/software/dlflib/include/dlflib/dlf_logger.h
@@ -62,8 +62,6 @@ class CSCLogger : public dlf::components::DlfComponent {
 
   void stopRun(run_handle_t h);
 
-  bool runIsActive(const char* uuid);
-
   WATCH(uint8_t)
   WATCH(uint16_t)
   WATCH(uint32_t)
@@ -98,6 +96,10 @@ class CSCLogger : public dlf::components::DlfComponent {
                                ticksToWait);
   }
 
+  std::vector<run_handle_t> getActiveRuns();
+
+  Run* getRun(run_handle_t h);
+
  private:
   CSCLogger& watchInternal(Encodable value, String id, const char* notes,
                            SemaphoreHandle_t mutex = NULL);
@@ -111,7 +113,7 @@ class CSCLogger : public dlf::components::DlfComponent {
 
   void prune();
 
-  std::unique_ptr<dlf::Run> runs_[MAX_RUNS];
+  std::unique_ptr<Run> runs_[MAX_RUNS];
   // Todo: Figure out how to do this with unique_ptrs
   dlf::datastream::streams_t streams_;
   fs::FS& fs_;

--- a/software/dlflib/include/dlflib/dlf_run.h
+++ b/software/dlflib/include/dlflib/dlf_run.h
@@ -21,9 +21,27 @@ class Run {
   Run(fs::FS& fs, String fsDir, dlf::datastream::streams_t streams,
       std::chrono::microseconds tickInterval, Encodable& meta);
 
+  /**
+   * End the run. Cleans up and closes out log files.
+   */
   void close();
 
   const char* uuid() { return uuid_.c_str(); }
+
+  /**
+   * Force a manual flush of log files.
+   */
+  void flushLogFiles();
+
+  /**
+   * Acquire locks on all log files.
+   */
+  void lockAllLogFiles();
+
+  /**
+   * Release locks on all log files.
+   */
+  void unlockAllLogFiles();
 
  private:
   static void taskSampler(void* arg);
@@ -43,6 +61,36 @@ class Run {
   dlf::datastream::streams_t streams_;
   std::vector<std::unique_ptr<LogFile>> logFiles_;
   String lockfilePath_;
+};
+
+/**
+ * RAII guard for locking and unlocking all LogFile mutexes for a specific Run.
+ */
+class RunLogFilesLock {
+ public:
+  explicit RunLogFilesLock(Run* run) : run_(run) {
+    if (run_) {
+      run_->lockAllLogFiles();
+    }
+  }
+
+  // Non-copyable
+  RunLogFilesLock(const RunLogFilesLock&) = delete;
+  RunLogFilesLock& operator=(const RunLogFilesLock&) = delete;
+
+  // Movable
+  RunLogFilesLock(RunLogFilesLock&& other) noexcept : run_(other.run_) {
+    other.run_ = nullptr;
+  }
+
+  ~RunLogFilesLock() {
+    if (run_) {
+      run_->unlockAllLogFiles();
+    }
+  }
+
+ private:
+  Run* run_;
 };
 
 }  // namespace dlf

--- a/software/oas-logger-v0/src/main.cpp
+++ b/software/oas-logger-v0/src/main.cpp
@@ -33,6 +33,7 @@ const bool USE_LEGACY_GPIO_CONFIG{false};
 const int LOGGER_RUN_INTERVAL_S{0};
 const bool LOGGER_MARK_AFTER_UPLOAD{true};
 const bool LOGGER_DELETE_AFTER_UPLOAD{false};
+const int LOGGER_PARTIAL_RUN_UPLOAD_INTERVAL_SECS{0};
 
 // Serial
 const unsigned long SERIAL_BAUD_RATE{115200};
@@ -279,6 +280,8 @@ void initializeLogger() {
   dlf::components::UploaderComponent::Options options;
   options.markAfterUpload = LOGGER_MARK_AFTER_UPLOAD;
   options.deleteAfterUpload = LOGGER_DELETE_AFTER_UPLOAD;
+  options.partialRunUploadIntervalSecs =
+      LOGGER_PARTIAL_RUN_UPLOAD_INTERVAL_SECS;
   logger.syncTo(UPLOAD_ENDPOINT, getDeviceUid(), options).begin();
 }
 

--- a/software/oas-logger-v1/src/main.cpp
+++ b/software/oas-logger-v1/src/main.cpp
@@ -12,15 +12,18 @@
 
 // Configuration
 const int SERIAL_BAUD_RATE{115200};
-const uint32_t LOGGER_MARK_AFTER_UPLOAD{100 * 1024};
+const int LOGGER_RUN_INTERVAL_S{0};
+const bool LOGGER_MARK_AFTER_UPLOAD{true};
 const bool LOGGER_DELETE_AFTER_UPLOAD{false};
+const int LOGGER_PARTIAL_RUN_UPLOAD_INTERVAL_SECS{0};
+const int WIFI_RECONFIG_BUTTON_HOLD_TIME_MS{2000};
+
+// Testing overrides
 const bool WAIT_FOR_VALID_TIME{true};
 const bool USE_LEGACY_GPIO_CONFIG{false};
 const bool USB_POWER_OVERRIDE{true};
 const bool USB_POWER_OVERRIDE_VALUE{true};
-const int LOGGER_RUN_INTERVAL_S{0};
 const int GPS_PRINT_INTERVAL_MS{1000};
-const int HOLD_TIME_MS{2000};
 
 // Pin Definitions
 const gpio_num_t PIN_USB_POWER{GPIO_NUM_13};
@@ -683,6 +686,8 @@ void initializeLogger() {
   dlf::components::UploaderComponent::Options options;
   options.markAfterUpload = LOGGER_MARK_AFTER_UPLOAD;
   options.deleteAfterUpload = LOGGER_DELETE_AFTER_UPLOAD;
+  options.partialRunUploadIntervalSecs =
+      LOGGER_PARTIAL_RUN_UPLOAD_INTERVAL_SECS;
   logger.syncTo(UPLOAD_ENDPOINT, getDeviceUid(), options).begin();
 
   Serial.println("Logger initialized");
@@ -722,7 +727,7 @@ void sleepMonitorTask(void* args) {
         unsigned long start = millis();
 
         while (!digitalRead(PIN_SLEEP_BUTTON)) {
-          if (millis() - start >= HOLD_TIME_MS) {
+          if (millis() - start >= WIFI_RECONFIG_BUTTON_HOLD_TIME_MS) {
             Serial.println(
                 "[WiFi Reconfiguration] WiFi reconfiguration mode entered...");
 
@@ -739,7 +744,7 @@ void sleepMonitorTask(void* args) {
           yield();
         }
 
-        if (millis() - start < HOLD_TIME_MS) {
+        if (millis() - start < WIFI_RECONFIG_BUTTON_HOLD_TIME_MS) {
           sleepCleanup();
           transitionToState(SystemState::OFFLOAD);
           break;


### PR DESCRIPTION
Adds a new UploaderComponent option `partialRunUploadIntervalSecs` - data for all active runs will be uploaded at this interval.

We start a new task that performs the uploading every interval, making sure to acquire the proper locks on the log files to avoid conflicts with the logfile flusher task.