### PR TITLE
[data-viz] Use cuidv2 for user id

### DIFF
--- a/software/data-visualizer/app/api/devices/route.ts
+++ b/software/data-visualizer/app/api/devices/route.ts
@@ -26,7 +26,6 @@ export async function GET() {
       orderBy: { createdAt: "desc" },
       select: {
         id: true,
-        deviceUid: true,
         name: true,
         createdAt: true,
       },

--- a/software/data-visualizer/app/api/upload/[uuid]/route.ts
+++ b/software/data-visualizer/app/api/upload/[uuid]/route.ts
@@ -43,10 +43,9 @@ export async function POST(
 
     // Ensure device exists (create if missing)
     const device = await prisma.device.upsert({
-      where: { deviceUid },
+      where: { id: deviceUid },
       update: {},
-      create: { deviceUid },
-      select: { id: true },
+      create: { id: deviceUid },
     });
 
     // Process isActive field (OPTIONAL)

--- a/software/data-visualizer/components/admin/create-device-form.tsx
+++ b/software/data-visualizer/components/admin/create-device-form.tsx
@@ -34,10 +34,10 @@ export default function CreateDeviceForm() {
 
       <form action={formAction} className="space-y-4">
         <div className="space-y-2">
-          <Label htmlFor="deviceUid">Device UID</Label>
+          <Label htmlFor="deviceId">Device UID</Label>
           <Input
-            id="deviceUid"
-            name="deviceUid"
+            id="deviceId"
+            name="deviceId"
             type="text"
             placeholder="unique-device-uid-123"
             required

--- a/software/data-visualizer/components/admin/create-user-form.tsx
+++ b/software/data-visualizer/components/admin/create-user-form.tsx
@@ -13,8 +13,7 @@ import { useActionState } from "react";
 import { useFormStatus } from "react-dom";
 
 type Device = {
-  id: number;
-  deviceUid: string;
+  id: string;
   name: string | null;
 };
 
@@ -81,7 +80,7 @@ export default function CreateUserForm({ devices }: { devices: Device[] }) {
                   className="h-4 w-4"
                 />
                 <span>
-                  {device.deviceUid}{" "}
+                  {device.id}{" "}
                   {device.name && (
                     <span className="text-xs text-muted-foreground">
                       ({device.name})

--- a/software/data-visualizer/components/admin/device-list.tsx
+++ b/software/data-visualizer/components/admin/device-list.tsx
@@ -19,8 +19,7 @@ import { useActionState, useEffect, useState } from "react";
 import { useFormStatus } from "react-dom";
 
 type Device = {
-  id: number;
-  deviceUid: string;
+  id: string;
   name: string | null;
 };
 
@@ -66,7 +65,7 @@ function UpdateDeviceForm({
       <div className="space-y-1">
         <Label>Device UID</Label>
         <p className="text-sm border rounded-md px-2 py-1 bg-muted text-muted-foreground">
-          {device.deviceUid}
+          {device.id}
         </p>
       </div>
 
@@ -138,7 +137,7 @@ export default function DeviceList({ devices }: { devices: Device[] }) {
               className="w-full text-left border rounded-md p-3 flex flex-col gap-1 hover:bg-muted transition"
             >
               <div className="flex justify-between items-center">
-                <span className="font-medium">{device.deviceUid}</span>
+                <span className="font-medium">{device.id}</span>
                 <span className="text-xs text-muted-foreground">
                   {device.name}
                 </span>
@@ -150,7 +149,7 @@ export default function DeviceList({ devices }: { devices: Device[] }) {
 
       <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
         {selectedDevice && (
-          <DialogContent className="sm:max-w-[480px]">
+          <DialogContent className="sm:max-w-120">
             <DialogHeader>
               <DialogTitle>Edit device</DialogTitle>
               <DialogDescription></DialogDescription>

--- a/software/data-visualizer/components/admin/user-list.tsx
+++ b/software/data-visualizer/components/admin/user-list.tsx
@@ -19,18 +19,17 @@ import { useActionState, useEffect, useState } from "react";
 import { useFormStatus } from "react-dom";
 
 type Device = {
-  id: number;
-  deviceUid: string;
+  id: string;
   name: string | null;
 };
 
 type UserDevice = {
-  deviceId: number;
+  deviceId: string;
   device: Device;
 };
 
 type User = {
-  id: number;
+  id: string;
   email: string;
   role: "USER" | "ADMIN";
   userDevices: UserDevice[];
@@ -135,7 +134,7 @@ function UpdateUserForm({
                   className="h-4 w-4"
                 />
                 <span>
-                  {device.deviceUid}{" "}
+                  {device.id}{" "}
                   {device.name && (
                     <span className="text-xs text-muted-foreground">
                       ({device.name})
@@ -221,7 +220,7 @@ export default function UserList({
                 {user.userDevices.length === 0 ? (
                   <span className="text-muted-foreground">none</span>
                 ) : (
-                  user.userDevices.map((ud) => ud.device.deviceUid).join(", ")
+                  user.userDevices.map((ud) => ud.device.id).join(", ")
                 )}
               </div>
             </button>
@@ -231,7 +230,7 @@ export default function UserList({
 
       <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
         {selectedUser && (
-          <DialogContent className="sm:max-w-[480px]">
+          <DialogContent className="sm:max-w-120">
             <DialogHeader>
               <DialogTitle>Edit user</DialogTitle>
               <DialogDescription></DialogDescription>

--- a/software/data-visualizer/lib/auth.ts
+++ b/software/data-visualizer/lib/auth.ts
@@ -14,12 +14,12 @@ export async function verifyPassword(pw: string, hash: string) {
   return bcrypt.compare(pw, hash);
 }
 
-export async function setSession(cookies: ResponseCookies, userId: number) {
+export async function setSession(cookies: ResponseCookies, userId: string) {
   // Note: calling `await cookies()` inside a helper does not reliably work for
   // responses as it may not be bound to the same response context as that in the
   // route handler. So, to be safe, we pass ResponseCookies in as a param that we
   // then modify.
-  const token = await new SignJWT({ sub: String(userId) })
+  const token = await new SignJWT({ sub: userId })
     .setProtectedHeader({ alg })
     .setIssuedAt()
     .setExpirationTime("7d")
@@ -34,7 +34,7 @@ export async function setSession(cookies: ResponseCookies, userId: number) {
   });
 }
 
-export async function getSession(): Promise<{ userId: number } | null> {
+export async function getSession(): Promise<{ userId: string } | null> {
   const cookieStore = await cookies();
   const token = cookieStore.get("session")?.value;
   if (!token) {
@@ -42,7 +42,7 @@ export async function getSession(): Promise<{ userId: number } | null> {
   }
   try {
     const { payload } = await jwtVerify(token, secret);
-    return payload?.sub ? { userId: Number(payload.sub) } : null;
+    return payload?.sub ? { userId: payload.sub } : null;
   } catch {
     return null;
   }

--- a/software/data-visualizer/prisma/migrations/20260106180327_init/migration.sql
+++ b/software/data-visualizer/prisma/migrations/20260106180327_init/migration.sql
@@ -9,34 +9,33 @@ CREATE TYPE "StreamType" AS ENUM ('POLLED', 'EVENT');
 
 -- CreateTable
 CREATE TABLE "User" (
-    "id" SERIAL NOT NULL,
+    "id" TEXT NOT NULL,
     "email" TEXT NOT NULL,
     "passwordHash" TEXT NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "role" "AppRole" NOT NULL DEFAULT 'USER',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "User_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
 CREATE TABLE "Device" (
-    "id" SERIAL NOT NULL,
-    "deviceUid" TEXT NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "id" TEXT NOT NULL,
     "name" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "Device_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
 CREATE TABLE "UserDevice" (
-    "userId" INTEGER NOT NULL,
-    "deviceId" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
+    "deviceId" TEXT NOT NULL,
     "role" "DeviceRole" NOT NULL DEFAULT 'VIEWER',
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "UserDevice_pkey" PRIMARY KEY ("userId","deviceId")
 );
@@ -45,13 +44,13 @@ CREATE TABLE "UserDevice" (
 CREATE TABLE "Run" (
     "id" SERIAL NOT NULL,
     "uuid" TEXT NOT NULL,
-    "deviceId" INTEGER NOT NULL,
+    "deviceId" TEXT NOT NULL,
     "epochTimeS" BIGINT NOT NULL,
     "tickBaseUs" BIGINT NOT NULL,
     "metadata" JSONB NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "isActive" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "Run_pkey" PRIMARY KEY ("id")
 );
@@ -70,9 +69,6 @@ CREATE TABLE "RunData" (
 
 -- CreateIndex
 CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
-
--- CreateIndex
-CREATE UNIQUE INDEX "Device_deviceUid_key" ON "Device"("deviceUid");
 
 -- CreateIndex
 CREATE INDEX "UserDevice_deviceId_role_idx" ON "UserDevice"("deviceId", "role");

--- a/software/data-visualizer/prisma/schema.prisma
+++ b/software/data-visualizer/prisma/schema.prisma
@@ -8,6 +8,10 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+// ------------------------------------------------------------
+// User and device management
+// ------------------------------------------------------------
+
 enum AppRole {
   ADMIN
   USER
@@ -18,28 +22,24 @@ enum DeviceRole {
   // Will add more in the future
 }
 
-enum StreamType {
-  POLLED
-  EVENT
-}
-
 model User {
-  id           Int      @id @default(autoincrement())
-  email        String   @unique
+  id           String  @id @default(cuid(2))
+  email        String  @unique
   passwordHash String
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @default(now()) @updatedAt
-  role         AppRole  @default(USER)
+  role         AppRole @default(USER)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   userDevices UserDevice[]
 }
 
 model Device {
-  id        Int      @id @default(autoincrement())
-  deviceUid String   @unique
+  id   String  @id
+  name String?
+
   createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
-  name      String?
+  updatedAt DateTime @updatedAt
 
   userDevices UserDevice[]
   runs        Run[]
@@ -47,31 +47,41 @@ model Device {
 
 model UserDevice {
   user     User   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId   Int // relation field
+  userId   String // relation field
   device   Device @relation(fields: [deviceId], references: [id], onDelete: Cascade)
-  deviceId Int // relation field
+  deviceId String // relation field
 
   role DeviceRole @default(VIEWER)
 
   createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  updatedAt DateTime @updatedAt
 
   @@id([userId, deviceId]) // each user-device pair is unique
   @@index([deviceId, role])
   @@index([userId, role])
 }
 
+// ------------------------------------------------------------
+// Runs and stream data
+// ------------------------------------------------------------
+
+enum StreamType {
+  POLLED
+  EVENT
+}
+
 model Run {
-  id         Int      @id @default(autoincrement())
-  uuid       String   @unique
-  device     Device   @relation(fields: [deviceId], references: [id], onDelete: Cascade)
-  deviceId   Int // relation field
+  id         Int     @id @default(autoincrement())
+  uuid       String  @unique
+  device     Device  @relation(fields: [deviceId], references: [id], onDelete: Cascade)
+  deviceId   String // relation field
   epochTimeS BigInt
   tickBaseUs BigInt
   metadata   Json
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @default(now()) @updatedAt
-  isActive   Boolean  @default(false)
+  isActive   Boolean @default(false)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   runData RunData[]
 }


### PR DESCRIPTION
- For User, use cuid v2 for ID. Advantages: safe to use in distributed systems; future proof in case we need to expose the id publicly, or use in admin pages to manage specific users
- For Device, consolidate the two ID fields to a single string ID. There is no reason to have two unique ids for a device. All ESP32 boards have a unique MAC address from eFuse memory (see getEfuseMac) that serves as the globally unique device ID
- Remove unnecessary @default(now()) from updatedAt fields