### PR TITLE
[oas-logger][ota] Add separate timeout for manifest fetch

### DIFF
--- a/software/oas-logger/lib/ota_updater/include/ota_updater/ota_updater.h
+++ b/software/oas-logger/lib/ota_updater/include/ota_updater/ota_updater.h
@@ -5,7 +5,6 @@
 namespace ota {
 
 struct Manifest {
-  bool hasLatest = false;
   String deviceType;
   String channel;
   String version;
@@ -25,7 +24,15 @@ class OtaUpdater {
     String channel;               // "STABLE" or "BETA"
     int currentBuildNumber = -1;  // currently installed build number
 
-    uint32_t httpTimeoutMs = 20000;
+    uint32_t manifestTimeoutMs = 3000;
+    uint32_t firmwareTimeoutMs = 20000;
+    uint32_t firmwareStallGraceMs = 5000;
+  };
+
+  struct ManifestResult {
+    bool ok = false;
+    String message;
+    Manifest manifest;
   };
 
   struct UpdateResult {
@@ -40,11 +47,9 @@ class OtaUpdater {
   /**
    * Fetch the latest manifest.
    *
-   * @param out The latest manifest data.
-   * @param err Error string, if the fetch was not successful.
-   * @return Whether the fetch was successful.
+   * @return The resulting state of the manifest fetch process.
    */
-  bool fetchLatestManifest(Manifest& out, String& err);
+  ManifestResult fetchLatestManifest();
 
   /**
    * Whether the manifest firmware version is newer than the one currently

--- a/software/oas-logger/src/factory_v0/main.cpp
+++ b/software/oas-logger/src/factory_v0/main.cpp
@@ -68,14 +68,14 @@ void setup() {
 
   ota::OtaUpdater::Config otaConfig;
   otaConfig.manifestEndpoint =
-      "http://192.168.1.71:3000/api/ota/manifest/%s/%s";
+      "https://oas-data-logger.vercel.app/api/ota/manifest/%s/%s";
   otaConfig.firmwareEndpoint =
-      "http://192.168.1.71:3000/api/ota/firmware/%s/%s/%d";
+      "https://oas-data-logger.vercel.app/api/ota/firmware/%s/%s/%d";
   otaConfig.deviceType = DEVICE_TYPE;
   otaConfig.channel = OTA_CHANNEL;
   otaConfig.currentBuildNumber = FW_BUILD_NUMBER;
   ota::OtaUpdater otaUpdater(otaConfig);
-  auto res = otaUpdater.updateIfAvailable(true);
+  auto res{otaUpdater.updateIfAvailable(true)};
   if (res.ok) {
     FastLED.showColor(CRGB::Green);
   } else {


### PR DESCRIPTION
Make sure we don't stall too long on backend latency/timeout, especially when no update is needed (since downloadAndUpdate will be run every time the device boots)