### PR TITLE
[oas-logger] Set board_build.filesystem to littlefs

### DIFF
--- a/software/oas-logger/platformio.ini
+++ b/software/oas-logger/platformio.ini
@@ -34,7 +34,7 @@ build_flags =
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 lib_ldf_mode = deep ; Makes PlatformIO detect nested library includes
-board_build.filesystem = sd_mmc ; Use SD card over SDIO
+board_build.filesystem = littlefs
 
 [env:v0-app]
 extends = env:v0-common
@@ -72,3 +72,4 @@ build_flags =
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 lib_ldf_mode = deep ; Makes PlatformIO detect nested library includes
+board_build.filesystem = littlefs


### PR DESCRIPTION
- The valid values for board_build.filesystem are spiffs, littlefs, and fatfs (source: https://docs.platformio.org/en/latest/platforms/espressif32.html). sd_mmc is actually not a valid value, and the behavior is unknown.
- SPIFFS is legacy and deprecated. LittleFS is recommended. 