### PR TITLE
[oas-logger] Fix WiFi connection on boot

### DIFF
--- a/software/oas-logger/src/app_v0/main.cpp
+++ b/software/oas-logger/src/app_v0/main.cpp
@@ -383,20 +383,6 @@ void handleWaitSdState() {
   vTaskDelay(pdMS_TO_TICKS(100));
 }
 
-bool wifiCredentialsExist() {
-  wifi_config_t conf;
-  esp_err_t result = esp_wifi_get_config(WIFI_IF_STA, &conf);
-
-  if (result != ESP_OK) {
-    Logger.log(OAS_ELOG_ID, ELOG_LEVEL_ERROR, "esp_wifi_get_config failed: %d",
-               result);
-    return false;
-  }
-
-  // Check if SSID is non-empty
-  return strlen((const char*)conf.sta.ssid) > 0;
-}
-
 bool getSavedSSID(char* out, size_t len) {
   wifi_config_t conf;
   if (esp_wifi_get_config(WIFI_IF_STA, &conf) != ESP_OK) {

--- a/software/oas-logger/src/app_v1/main.cpp
+++ b/software/oas-logger/src/app_v1/main.cpp
@@ -451,6 +451,17 @@ void handleWaitSdState() {
   }
 }
 
+bool getSavedSSID(char* out, size_t len) {
+  wifi_config_t conf;
+  if (esp_wifi_get_config(WIFI_IF_STA, &conf) != ESP_OK) {
+    return false;
+  }
+
+  strncpy(out, (const char*)conf.sta.ssid, len);
+  out[len - 1] = '\0';
+  return strlen(out) > 0;
+}
+
 void handleWaitWifiState() {
   Logger.log(OAS_ELOG_ID, ELOG_LEVEL_INFO, "Initializing WiFi (STA)...");
 


### PR DESCRIPTION
- Changed the way we check if wifi credentials are already stored on device. WiFi.SSID() did not work for me (and it shouldn't, as it returns the SSID of the connected access point). 
- We should only stop the reconnection attempt when ARDUINO_EVENT_WIFI_STA_GOT_IP is fired
- Fixed a bug where we were checking status 201 as AUTH_FAIL (it's actually 202, and we should be using the enum)
- Annoyingly, sometimes a disconnect with AUTH_FAIL will fire on the first connection attempt even though credentials are valid. Just ignore this event for now. If invalid credentials are indeed stored on the device, then we'll eventually continue.