### PR TITLE
[data-viz] Add API endpoint to delete run

### DIFF
--- a/software/data-visualizer/prisma/migrations/20260127155021_cascade_run_delete/migration.sql
+++ b/software/data-visualizer/prisma/migrations/20260127155021_cascade_run_delete/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "RunData" DROP CONSTRAINT "RunData_runId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "RunData" ADD CONSTRAINT "RunData_runId_fkey" FOREIGN KEY ("runId") REFERENCES "Run"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/software/data-visualizer/prisma/schema.prisma
+++ b/software/data-visualizer/prisma/schema.prisma
@@ -49,9 +49,9 @@ model Device {
 
 model DeviceSecret {
   deviceId String @id
-  
+
   // This stores the encrypted secret.
-  secret   String 
+  secret String
 
   encryptionKeyVersion Int @default(1)
 
@@ -105,7 +105,7 @@ model Run {
 
 model RunData {
   id         Int        @id @default(autoincrement())
-  run        Run        @relation(fields: [runId], references: [id])
+  run        Run        @relation(fields: [runId], references: [id], onDelete: Cascade)
   runId      Int // relation field
   streamType StreamType
   streamId   String


### PR DESCRIPTION
This adds a schema migration that adds onDelete: cascade for RunData <-> Run, so that when we delete a Run, all its RunData is automatically deleted as well