### PR TITLE
[data-viz] Make Combobox and selector components controlled and add delete run button to main page

### DIFF
--- a/software/data-visualizer/components/data-selector.tsx
+++ b/software/data-visualizer/components/data-selector.tsx
@@ -2,28 +2,135 @@
 
 import DeviceSelector from "@/components/device-selector";
 import RunSelector from "@/components/run-selector";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import VisualizationSelector from "@/components/visualization-selector";
 import { useEffect, useState } from "react";
 
 export default function DataSelector() {
   const [selectedDevice, setSelectedDevice] = useState<string>("");
   const [selectedRun, setSelectedRun] = useState<string>("");
+  const [selectedVisualization, setSelectedVisualization] = useState("");
+
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteErrorMsg, setDeleteErrorMsg] = useState<string>("");
+
+  // Used to force RunSelector to refetch runs after deleting a run
+  const [runsRefreshKey, setRunsRefreshKey] = useState(0);
 
   // Clear selectedRun whenever the device changes
   useEffect(() => {
     setSelectedRun("");
   }, [selectedDevice]);
 
+  async function handleDeleteRun() {
+    if (!selectedRun) {
+      return;
+    }
+
+    setIsDeleting(true);
+    setDeleteErrorMsg("");
+
+    try {
+      const res = await fetch(`/api/runs/${selectedRun}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        let msg = "Failed to delete run";
+        try {
+          const data = await res.json();
+          if (data?.error) {
+            msg = data.error;
+          }
+        } catch {}
+        throw new Error(msg);
+      }
+
+      setDeleteOpen(false);
+      setSelectedRun(""); // unselect the run when successfully deleted
+      setRunsRefreshKey((k) => k + 1); // refresh the run list
+    } catch (e) {
+      setDeleteErrorMsg(
+        e instanceof Error ? e.message : "Failed to delete run",
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
   return (
     <>
-      <DeviceSelector onSelect={(deviceId) => setSelectedDevice(deviceId)} />
+      <DeviceSelector
+        value={selectedDevice}
+        onValueChange={setSelectedDevice}
+      />
+
       {selectedDevice && (
         <RunSelector
+          // Forcing remount triggers a re-fetch when we bump runsRefreshKey
+          key={`${selectedDevice}:${runsRefreshKey}`}
           deviceId={selectedDevice}
-          onSelect={(runUuid) => setSelectedRun(runUuid)}
+          value={selectedRun}
+          onValueChange={setSelectedRun}
         />
       )}
-      {selectedRun && <VisualizationSelector runUuid={selectedRun} />}
+
+      {selectedRun && (
+        <VisualizationSelector
+          runUuid={selectedRun}
+          value={selectedVisualization}
+          onValueChange={setSelectedVisualization}
+        />
+      )}
+
+      {selectedRun && (
+        <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+          <DialogTrigger asChild>
+            <Button variant="destructive">Delete Run</Button>
+          </DialogTrigger>
+
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Delete this run?</DialogTitle>
+              <DialogDescription>
+                This will permanently delete the run and its associated data.
+                This action cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+
+            {deleteErrorMsg && (
+              <p className="text-sm text-destructive">{deleteErrorMsg}</p>
+            )}
+
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setDeleteOpen(false)}
+                disabled={isDeleting}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleDeleteRun}
+                disabled={isDeleting}
+              >
+                {isDeleting ? "Deleting..." : "Confirm Delete"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
     </>
   );
 }

--- a/software/data-visualizer/components/ui/dialog.tsx
+++ b/software/data-visualizer/components/ui/dialog.tsx
@@ -1,33 +1,33 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Dialog({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
 function DialogTrigger({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
 function DialogPortal({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
 function DialogClose({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Close>) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
 function DialogOverlay({
@@ -38,12 +38,12 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-1000 bg-black/50",
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogContent({
@@ -52,7 +52,7 @@ function DialogContent({
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
@@ -60,8 +60,8 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
-          className
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-1000 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className,
         )}
         {...props}
       >
@@ -77,7 +77,7 @@ function DialogContent({
         )}
       </DialogPrimitive.Content>
     </DialogPortal>
-  )
+  );
 }
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -87,7 +87,7 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
       {...props}
     />
-  )
+  );
 }
 
 function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -96,11 +96,11 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="dialog-footer"
       className={cn(
         "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogTitle({
@@ -113,7 +113,7 @@ function DialogTitle({
       className={cn("text-lg leading-none font-semibold", className)}
       {...props}
     />
-  )
+  );
 }
 
 function DialogDescription({
@@ -126,7 +126,7 @@ function DialogDescription({
       className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -140,4 +140,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-}
+};


### PR DESCRIPTION
Instead of mixing controlled and uncontrolled selection state between DataSelector and Combobox, we modify Combobox to support both uncontrolled (selected state owned and managed internally in the Combobox) and controlled mode (selected state owned and managed by the parent component of Combobox), and lift all selected state to DataSelector, which becomes the source of truth. Thus, DeviceSelector, RunSelector, VisualizationSelector all become controlled components, all using the controlled mode of Combobox.