### PR TITLE
[data-viz] Move user role checks for prisma queries into a common lib

### DIFF
--- a/software/data-visualizer/app/api/devices/route.ts
+++ b/software/data-visualizer/app/api/devices/route.ts
@@ -1,6 +1,7 @@
-import prisma from "@/lib/prisma";
-import { NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { devicesWhereForUser } from "@/lib/query-helpers";
+import { NextResponse } from "next/server";
 
 export async function GET() {
   try {
@@ -9,18 +10,7 @@ export async function GET() {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // ADMINs can view everything
-    // USERs can only view devices they are associated with
-    const where =
-      user.role === "ADMIN"
-        ? {}
-        : {
-            userDevices: {
-              some: {
-                userId: user.id,
-              },
-            },
-          };
+    const where = devicesWhereForUser(user);
     const devices = await prisma.device.findMany({
       where,
       orderBy: { createdAt: "desc" },
@@ -36,7 +26,7 @@ export async function GET() {
     console.error("GET /api/devices error:", err);
     return NextResponse.json(
       { error: "Failed to fetch devices" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/software/data-visualizer/app/api/runs/[uuid]/streams/[stream_id]/route.ts
+++ b/software/data-visualizer/app/api/runs/[uuid]/streams/[stream_id]/route.ts
@@ -1,10 +1,11 @@
-import prisma from "@/lib/prisma";
-import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { getRunForUser } from "@/lib/query-helpers";
+import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: Promise<{ uuid: string; stream_id: string }> }
+  { params }: { params: Promise<{ uuid: string; stream_id: string }> },
 ) {
   const { uuid, stream_id } = await params;
 
@@ -14,26 +15,7 @@ export async function GET(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // ADMINs can view everything
-    // USERs can only view runs for devices they are associated with
-    const runWhere =
-      user.role === "ADMIN"
-        ? { uuid }
-        : {
-            uuid,
-            device: {
-              userDevices: {
-                some: {
-                  userId: user.id,
-                },
-              },
-            },
-          };
-    const run = await prisma.run.findFirst({
-      where: runWhere,
-      select: { id: true },
-    });
-
+    const run = await getRunForUser(user, uuid, { select: { id: true } });
     if (!run) {
       // Either run doesn't exist, or user has no access to it
       return NextResponse.json({ error: "Run not found" }, { status: 404 });
@@ -58,13 +40,13 @@ export async function GET(
       runData.map((d) => ({
         ...d,
         tick: d.tick.toString(),
-      }))
+      })),
     );
   } catch (err) {
     console.error("GET /api/runs/[uuid]/streams/[stream_id] error:", err);
     return NextResponse.json(
       { error: "Error retrieving run data" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/software/data-visualizer/app/api/runs/route.ts
+++ b/software/data-visualizer/app/api/runs/route.ts
@@ -1,5 +1,6 @@
 import { getCurrentUser } from "@/lib/auth";
 import prisma from "@/lib/prisma";
+import { runsWhereForUser } from "@/lib/query-helpers";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
@@ -12,21 +13,7 @@ export async function GET(req: NextRequest) {
     const { searchParams } = new URL(req.url);
     const deviceId = searchParams.get("device_id");
 
-    // ADMINs can view everything
-    // USERs can only view runs for devices they are associated with
-    const authWhere =
-      user.role === "ADMIN"
-        ? {}
-        : {
-            device: {
-              userDevices: {
-                some: {
-                  userId: user.id,
-                },
-              },
-            },
-          };
-
+    const authWhere = runsWhereForUser(user);
     // Device filter if deviceId query param exists
     const deviceWhere = deviceId
       ? {

--- a/software/data-visualizer/lib/auth.ts
+++ b/software/data-visualizer/lib/auth.ts
@@ -7,9 +7,16 @@ import { cookies } from "next/headers";
 const alg = "HS256";
 const secret = new TextEncoder().encode(process.env.AUTH_SECRET);
 
+export type User = {
+  id: string;
+  role: "USER" | "ADMIN";
+  email: string;
+};
+
 export async function hashPassword(pw: string) {
   return bcrypt.hash(pw, 12);
 }
+
 export async function verifyPassword(pw: string, hash: string) {
   return bcrypt.compare(pw, hash);
 }
@@ -56,7 +63,7 @@ export async function clearSession(cookies: ResponseCookies) {
   cookies.delete("session");
 }
 
-export async function getCurrentUser() {
+export async function getCurrentUser(): Promise<User | null> {
   const session = await getSession();
   if (!session) {
     return null;

--- a/software/data-visualizer/lib/query-helpers.ts
+++ b/software/data-visualizer/lib/query-helpers.ts
@@ -1,0 +1,82 @@
+import type { User } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import type { Prisma, Run } from "@/generated/prisma/client";
+
+export function runWhereForUser(
+  user: User,
+  uuid: string,
+): Prisma.RunWhereInput {
+  // ADMINs can access all runs.
+  // Others can only access runs for devices they are associated with.
+  const where =
+    user.role === "ADMIN"
+      ? { uuid }
+      : {
+          uuid,
+          device: {
+            userDevices: {
+              some: {
+                userId: user.id,
+              },
+            },
+          },
+        };
+  return where;
+}
+
+export function runsWhereForUser(user: User): Prisma.RunWhereInput {
+  // ADMINs can access all runs.
+  // Others can only access runs for devices they are associated with.
+  const where =
+    user.role === "ADMIN"
+      ? {}
+      : {
+          device: {
+            userDevices: {
+              some: {
+                userId: user.id,
+              },
+            },
+          },
+        };
+  return where;
+}
+
+export function devicesWhereForUser(user: User): Prisma.DeviceWhereInput {
+  // ADMINs can access all devices.
+  // USERs can only access devices they are associated with.
+  const where =
+    user.role === "ADMIN"
+      ? {}
+      : {
+          userDevices: {
+            some: {
+              userId: user.id,
+            },
+          },
+        };
+  return where;
+}
+
+/**
+ * Get run by UUID.
+ *
+ * @param user
+ * @param uuid
+ * @param options
+ * @returns Returns the Run if it exists and the user is allowed to access it, otherwise null.
+ */
+export async function getRunForUser(
+  user: User,
+  uuid: string,
+  options?: {
+    select?: Prisma.RunSelect;
+    include?: Prisma.RunInclude;
+  },
+): Promise<Run | null> {
+  const where = runWhereForUser(user, uuid);
+  return prisma.run.findFirst({
+    where,
+    ...options,
+  });
+}


### PR DESCRIPTION
Motivation: reduce the risk of forgetting this check on new endpoints in the future, and centralize the auth checks for readability/maintainability