### PR TITLE
[oas-logger] Switch to EzLog

### DIFF
--- a/software/dlflib/include/dlflib/log.h
+++ b/software/dlflib/include/dlflib/log.h
@@ -1,16 +1,16 @@
 #pragma once
 
-#ifdef DLFLIB_USE_ADVANCED_LOGGER
+#ifdef DLFLIB_USE_EZLOG
 
-#include <AdvancedLogger.h>
+#include <EzLog.h>
 
-#define DLFLIB_LOG_ERROR(fmt, ...) LOG_ERROR(fmt, ##__VA_ARGS__)
+#define DLFLIB_LOG_ERROR(fmt, ...) EZLOG_ERROR(fmt, ##__VA_ARGS__)
 
-#define DLFLIB_LOG_WARNING(fmt, ...) LOG_WARNING(fmt, ##__VA_ARGS__)
+#define DLFLIB_LOG_WARNING(fmt, ...) EZLOG_WARN(fmt, ##__VA_ARGS__)
 
-#define DLFLIB_LOG_INFO(fmt, ...) LOG_INFO(fmt, ##__VA_ARGS__)
+#define DLFLIB_LOG_INFO(fmt, ...) EZLOG_INFO(fmt, ##__VA_ARGS__)
 
-#define DLFLIB_LOG_DEBUG(fmt, ...) LOG_DEBUG(fmt, ##__VA_ARGS__)
+#define DLFLIB_LOG_DEBUG(fmt, ...) EZLOG_DEBUG(fmt, ##__VA_ARGS__)
 
 #else
 

--- a/software/oas-logger/lib/memory_monitor/include/memory_monitor/memory_monitor.h
+++ b/software/oas-logger/lib/memory_monitor/include/memory_monitor/memory_monitor.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <AdvancedLogger.h>
 #include <Arduino.h>
+#include <EzLog.h>
 #include <esp_heap_caps.h>
 
 namespace memory_monitor {
@@ -12,18 +12,18 @@ inline void logHeap(const char* tag) {
   size_t free8Bit{heap_caps_get_free_size(MALLOC_CAP_8BIT)};
   size_t min8Bit{heap_caps_get_minimum_free_size(MALLOC_CAP_8BIT)};
   size_t largest8Bit{heap_caps_get_largest_free_block(MALLOC_CAP_8BIT)};
-  LOG_INFO("[%s] 8bit: total=%u, free=%u, min=%u, largest=%u\n", tag,
-           (unsigned)total8Bit, (unsigned)free8Bit, (unsigned)min8Bit,
-           (unsigned)largest8Bit);
+  EZLOG_INFO("[%s] 8bit: total=%u, free=%u, min=%u, largest=%u\n", tag,
+             (unsigned)total8Bit, (unsigned)free8Bit, (unsigned)min8Bit,
+             (unsigned)largest8Bit);
 
   // Internal memory (on chip)
   size_t totalInternal{heap_caps_get_total_size(MALLOC_CAP_INTERNAL)};
   size_t freeInternal{heap_caps_get_free_size(MALLOC_CAP_INTERNAL)};
   size_t minInternal{heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL)};
   size_t largestInternal{heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL)};
-  LOG_INFO("[%s] internal: total=%u, free=%u, min=%u, largest=%u\n", tag,
-           (unsigned)totalInternal, (unsigned)freeInternal,
-           (unsigned)minInternal, (unsigned)largestInternal);
+  EZLOG_INFO("[%s] internal: total=%u, free=%u, min=%u, largest=%u\n", tag,
+             (unsigned)totalInternal, (unsigned)freeInternal,
+             (unsigned)minInternal, (unsigned)largestInternal);
 
 #if CONFIG_SPIRAM
   // External PSRAM
@@ -31,9 +31,9 @@ inline void logHeap(const char* tag) {
   size_t freePsram{heap_caps_get_free_size(MALLOC_CAP_SPIRAM)};
   size_t minPsram{heap_caps_get_minimum_free_size(MALLOC_CAP_SPIRAM)};
   size_t largestPsram{heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM)};
-  LOG_INFO("[%s] psram: total=%u, free=%u, min=%u, largest=%u\n", tag,
-           (unsigned)totalPsram, (unsigned)freePsram, (unsigned)minPsram,
-           (unsigned)largestPsram);
+  EZLOG_INFO("[%s] psram: total=%u, free=%u, min=%u, largest=%u\n", tag,
+             (unsigned)totalPsram, (unsigned)freePsram, (unsigned)minPsram,
+             (unsigned)largestPsram);
 #endif
 }
 

--- a/software/oas-logger/platformio.ini
+++ b/software/oas-logger/platformio.ini
@@ -16,14 +16,13 @@ build_flags =
   -DOTA_CHANNEL=\"STABLE\"
   -DFW_BUILD_NUMBER=1
   -DFW_VERSION=\"0.0.1\"
-  -DDLFLIB_USE_ADVANCED_LOGGER
+  -DDLFLIB_USE_EZLOG
 lib_deps =
   dlflib=symlink://../dlflib
   fastled/FastLED@^3.9.0
   fbiego/ESP32Time@^2.0.6
   tzapu/WiFiManager@^2.0.17
   sparkfun/SparkFun u-blox GNSS v3@^3.1.13
-  jijio/AdvancedLogger@^2.0.1
 
 [env:v1-factory]
 extends = env:v1-common
@@ -53,14 +52,13 @@ build_flags =
   -DOTA_CHANNEL=\"STABLE\"
   -DFW_BUILD_NUMBER=1
   -DFW_VERSION=\"0.0.1\"
-  -DDLFLIB_USE_ADVANCED_LOGGER
+  -DDLFLIB_USE_EZLOG
 lib_deps =
   dlflib=symlink://../dlflib
   fastled/FastLED@^3.9.0
   mikalhart/TinyGPSPlus@^1.1.0
   fbiego/ESP32Time@^2.0.6
   tzapu/WiFiManager@^2.0.17
-  jijio/AdvancedLogger@^2.0.1
 
 [env:v0-factory]
 extends = env:v0-common

--- a/software/oas-logger/src/app_v1/main.cpp
+++ b/software/oas-logger/src/app_v1/main.cpp
@@ -1,7 +1,7 @@
-#include <AdvancedLogger.h>
 #include <Arduino.h>
 #include <DeviceAuth.h>
 #include <ESP32Time.h>
+#include <EzLog.h>
 #include <FastLED.h>
 #include <SD_MMC.h>
 #include <SparkFun_u-blox_GNSS_v3.h>
@@ -175,18 +175,13 @@ void setup() {
   // Delay here to give dev some time to connect to Serial Monitor
   vTaskDelay(pdMS_TO_TICKS(3000));
 
-  // Initialize AdvancedLogger
-  if (!LittleFS.begin(true)) {
-    Serial.println(
-        "LittleFS mount failed! AdvancedLogger will not log to LittleFS.");
-  }
-  AdvancedLogger::begin();
-  AdvancedLogger::setPrintLevel(LogLevel::INFO);
-  AdvancedLogger::setSaveLevel(LogLevel::INFO);
+  // Initialize EzLog
+  ezlog::addSerial();
+  ezlog::addLittleFS();
 
-  LOG_INFO("****System Boot****");
-  LOG_INFO("Firmware: version=%s build=%d device=%s channel=%s", FW_VERSION,
-           FW_BUILD_NUMBER, DEVICE_TYPE, OTA_CHANNEL);
+  EZLOG_INFO("****System Boot****");
+  EZLOG_INFO("Firmware: version=%s build=%d device=%s channel=%s", FW_VERSION,
+             FW_BUILD_NUMBER, DEVICE_TYPE, OTA_CHANNEL);
 
   provisionDevice();
 
@@ -273,18 +268,18 @@ void loop() {
 void onWiFiEvent(WiFiEvent_t event, WiFiEventInfo_t info) {
   switch (event) {
     case ARDUINO_EVENT_WIFI_STA_START:
-      LOG_INFO("[WiFi] STA started");
+      EZLOG_INFO("[WiFi] STA started");
       break;
     case ARDUINO_EVENT_WIFI_STA_GOT_IP:
       // Note: only consider connection as successful when we got the IP, not on
       // ARDUINO_EVENT_WIFI_STA_CONNECTED
-      LOG_INFO("[WiFi] Got IP");
+      EZLOG_INFO("[WiFi] Got IP");
       wifiConnecting = false;
       wifiReconnectBackoff = WIFI_RECONNECT_BACKOFF_MS;  // Reset backoff
       break;
     case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
-      LOG_INFO("[WiFi] Disconnected, reason: %d",
-               info.wifi_sta_disconnected.reason);
+      EZLOG_INFO("[WiFi] Disconnected, reason: %d",
+                 info.wifi_sta_disconnected.reason);
 
       if (info.wifi_sta_disconnected.reason == WIFI_REASON_AUTH_FAIL) {
         // Annoyingly, sometimes a disconnect with AUTH_FAIL will fire on the
@@ -317,15 +312,15 @@ void initializeLed() {
 void provisionDevice() {
   device_auth::DeviceAuth auth(getDeviceUid());
   if (!auth.loadSecret(deviceSecret)) {
-    LOG_INFO("Device unprovisioned. Waiting for script...");
+    EZLOG_INFO("Device unprovisioned. Waiting for script...");
 
     deviceSecret = auth.awaitProvisioning();
 
-    LOG_INFO("Provisioning successful. Rebooting in 3s...");
+    EZLOG_INFO("Provisioning successful. Rebooting in 3s...");
     delay(3000);
     restart();
   } else {
-    LOG_INFO("Device already provisioned");
+    EZLOG_INFO("Device already provisioned");
   }
 }
 
@@ -393,7 +388,7 @@ void updateLedPattern() {
 }
 
 void transitionToState(SystemState newState) {
-  LOG_DEBUG("State transition: %d -> %d", (int)currentState, (int)newState);
+  EZLOG_DEBUG("State transition: %d -> %d", (int)currentState, (int)newState);
   currentState = newState;
 
   // Reset LED toggle state on transition
@@ -404,36 +399,36 @@ void transitionToState(SystemState newState) {
 void handleInitState() { transitionToState(SystemState::WAIT_SD); }
 
 void handleWaitSdState() {
-  LOG_INFO("Initializing SDIO for SD card...");
+  EZLOG_INFO("Initializing SDIO for SD card...");
 
   // Configure the pins for SDIO
   if (!SD_MMC.setPins(PIN_SD_CLK, PIN_SD_CMD, PIN_SD_D0, PIN_SD_D1, PIN_SD_D2,
                       PIN_SD_D3)) {
-    LOG_ERROR("Pin configuration failed!");
+    EZLOG_ERROR("Pin configuration failed!");
     currentError = ErrorType::SD_INIT_FAILED;
     transitionToState(SystemState::ERROR);
     return;
   }
 
   // Try 1-bit mode first (more reliable)
-  LOG_INFO("Trying 1-bit mode...");
+  EZLOG_INFO("Trying 1-bit mode...");
   if (SD_MMC.begin("/sdcard", true)) {  // true = use 1-bit mode
-    LOG_INFO("SD card connected via SDIO (1-bit mode)");
+    EZLOG_INFO("SD card connected via SDIO (1-bit mode)");
 
     // Optionally try 4-bit mode
     SD_MMC.end();
     delay(100);
-    LOG_INFO("Now trying 4-bit mode...");
+    EZLOG_INFO("Now trying 4-bit mode...");
     if (SD_MMC.begin("/sdcard", true, false,
                      SDMMC_FREQ_DEFAULT)) {  // false = 4-bit mode
-      LOG_INFO("SD card connected via SDIO (4-bit mode)");
+      EZLOG_INFO("SD card connected via SDIO (4-bit mode)");
     } else {
-      LOG_WARNING("4-bit failed, falling back to 1-bit");
+      EZLOG_WARN("4-bit failed, falling back to 1-bit");
       SD_MMC.begin("/sdcard", true);
     }
     transitionToState(SystemState::WAIT_WIFI);
   } else {
-    LOG_ERROR("SD card initialization failed even in 1-bit mode");
+    EZLOG_ERROR("SD card initialization failed even in 1-bit mode");
     currentError = ErrorType::SD_INIT_FAILED;
     transitionToState(SystemState::ERROR);
   }
@@ -451,7 +446,7 @@ bool getSavedSSID(char* out, size_t len) {
 }
 
 void handleWaitWifiState() {
-  LOG_INFO("Initializing WiFi (STA)...");
+  EZLOG_INFO("Initializing WiFi (STA)...");
 
   // Set WiFi mode and register event handler
   WiFi.mode(WIFI_STA);
@@ -462,12 +457,12 @@ void handleWaitWifiState() {
   char ssid[33];
   if (getSavedSSID(ssid, sizeof(ssid))) {
     // If we have saved credentials, attempt to connect to it
-    LOG_INFO("Connecting to saved WiFi: %s", ssid);
+    EZLOG_INFO("Connecting to saved WiFi: %s", ssid);
     WiFi.begin();
     wifiConnecting = true;
   } else {
     // If we don't have saved credentials, start Config Portal
-    LOG_INFO("No saved WiFi credentials found. Starting WiFi Manager...");
+    EZLOG_INFO("No saved WiFi credentials found. Starting WiFi Manager...");
     wifiManager.autoConnect();
   }
 
@@ -478,9 +473,9 @@ void handleWaitWifiState() {
   }
 
   if (WiFi.status() == WL_CONNECTED) {
-    LOG_INFO("WiFi connected successfully");
+    EZLOG_INFO("WiFi connected successfully");
   } else {
-    LOG_INFO("WiFi not connected; continuing without network.");
+    EZLOG_INFO("WiFi not connected; continuing without network.");
   }
 
   if (offloadMode) {
@@ -505,7 +500,7 @@ void handleOtaUpdate() {
   ota::OtaUpdater otaUpdater(otaConfig);
   auto res{otaUpdater.updateIfAvailable(true)};
   if (!res.ok) {
-    LOG_ERROR("[OTA] Error when updating firmware: %s", res.message.c_str());
+    EZLOG_ERROR("[OTA] Error when updating firmware: %s", res.message.c_str());
   }
 
   transitionToState(SystemState::WAIT_GPS);
@@ -533,7 +528,7 @@ void handleWaitTimeState() {
     // Also set the RTC
     rtc.setTime(gpsEpoch);
 
-    LOG_INFO("Valid GPS time received: %ld", gpsEpoch);
+    EZLOG_INFO("Valid GPS time received: %ld", gpsEpoch);
 
     // Initialize logger and start run
     initializeDLFLogger();
@@ -545,7 +540,7 @@ void handleWaitTimeState() {
     const unsigned long now{millis()};
     if (now - lastPrintTimeMillis > 5000) {
       lastPrintTimeMillis = now;
-      LOG_INFO("Waiting for valid GPS time...");
+      EZLOG_INFO("Waiting for valid GPS time...");
     }
   }
 }
@@ -560,10 +555,10 @@ void handleRunningState() {
 
     // Try to get GPS data with mutex protection
     if (xSemaphoreTake(gpsDataMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
-      LOG_DEBUG("[GPS] Lat: %.6f, Lng: %.6f, Alt: %.1fm, Sats: %d, Fix: %d",
-                gpsData.lat, gpsData.lng, gpsData.alt, gpsData.satellites,
-                gpsFixType);
-      LOG_DEBUG("[DIAG] RunHandle: %d, Uptime: %lu ms\n", runHandle, now);
+      EZLOG_DEBUG("[GPS] Lat: %.6f, Lng: %.6f, Alt: %.1fm, Sats: %d, Fix: %d",
+                  gpsData.lat, gpsData.lng, gpsData.alt, gpsData.satellites,
+                  gpsFixType);
+      EZLOG_DEBUG("[DIAG] RunHandle: %d, Uptime: %lu ms\n", runHandle, now);
       xSemaphoreGive(gpsDataMutex);
     }
   }
@@ -592,7 +587,7 @@ void handleErrorState() {
   if (!wasInError) {
     // Just entered the ERROR state. This block should only be run once when we
     // first enter this state
-    LOG_ERROR("System in ERROR state. Error type: %d", (int)currentError);
+    EZLOG_ERROR("System in ERROR state. Error type: %d", (int)currentError);
     errorStartMillis = millis();
     wasInError = true;
   }
@@ -604,7 +599,7 @@ void handleErrorState() {
 }
 
 void handleSleepState() {
-  LOG_INFO("Entering deep sleep...");
+  EZLOG_INFO("Entering deep sleep...");
 
   // Stop all tasks
   disableGps();
@@ -618,8 +613,6 @@ void handleSleepState() {
   } else {
     esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
   }
-
-  AdvancedLogger::end();
 
   // Enter deep sleep
   esp_deep_sleep_start();
@@ -637,7 +630,7 @@ void enableGps() {
     return;
   }
 
-  LOG_INFO("Enabling GPS...");
+  EZLOG_INFO("Enabling GPS...");
 
   // Power cycle the GPS module (TESTED AND WORKING)
   // Note: PIN_GPS_ENABLE is already HIGH from setup() (shared with SD card)
@@ -662,7 +655,7 @@ void enableGps() {
     }
   }
   if (!connected) {
-    LOG_ERROR("GPS not responding");
+    EZLOG_ERROR("GPS not responding");
     currentError = ErrorType::GPS_NOT_RESPONDING;
     transitionToState(SystemState::ERROR);
     return;
@@ -674,11 +667,11 @@ void enableGps() {
   myGNSS.saveConfiguration();
 
   gpsEnabled = true;
-  LOG_INFO("GPS enabled");
+  EZLOG_INFO("GPS enabled");
 }
 
 void gpsTask(void* args) {
-  LOG_INFO("[GPS Task] Started");
+  EZLOG_INFO("[GPS Task] Started");
 
   while (true) {
     // Request PVT data - returns true when new data is available
@@ -737,11 +730,11 @@ void disableGps() {
     return;
   }
 
-  LOG_INFO("Disabling GPS...");
+  EZLOG_INFO("Disabling GPS...");
 
   // Delete GPS task if it exists
   if (xGPS_Handle != NULL) {
-    LOG_INFO("[GPS] Deleting GPS task...");
+    EZLOG_INFO("[GPS] Deleting GPS task...");
     vTaskDelete(xGPS_Handle);
     xGPS_Handle = NULL;
   }
@@ -755,7 +748,7 @@ void disableGps() {
   GPS_SERIAL.end();
 
   gpsEnabled = false;
-  LOG_INFO("GPS disabled");
+  EZLOG_INFO("GPS disabled");
 }
 
 String getDeviceUid() {
@@ -766,7 +759,7 @@ String getDeviceUid() {
 }
 
 void initializeDLFLogger() {
-  LOG_INFO("Initializing DLF logger...");
+  EZLOG_INFO("Initializing DLF logger...");
 
   auto satellitesLogInterval{std::chrono::seconds(5)};
   POLL(logger, gpsData.satellites, satellitesLogInterval, gpsDataMutex);
@@ -783,7 +776,7 @@ void initializeDLFLogger() {
       LOGGER_PARTIAL_RUN_UPLOAD_INTERVAL_SECS;
   logger.syncTo(UPLOAD_ENDPOINT, getDeviceUid(), deviceSecret, options).begin();
 
-  LOG_INFO("DLF logger initialized");
+  EZLOG_INFO("DLF logger initialized");
 }
 
 void startLoggerRun() {
@@ -822,15 +815,16 @@ void sleepMonitorTask(void* args) {
         while (!digitalRead(PIN_SLEEP_BUTTON)) {
           if (millis() - start >= WIFI_RECONFIG_BUTTON_HOLD_TIME_MS) {
             // Sleep button has been long pressed
-            LOG_INFO(
+            EZLOG_INFO(
                 "[WiFi Reconfiguration] WiFi reconfiguration mode entered...");
 
             sleepCleanup();
             vTaskDelay(pdMS_TO_TICKS(100));
             logger.waitForSyncCompletion();
-            LOG_INFO("[WiFi Reconfiguration] Resetting WiFiManager...");
+            EZLOG_INFO("[WiFi Reconfiguration] Resetting WiFiManager...");
             wifiManager.resetSettings();  // uses vTaskDelay internally
-            LOG_INFO("[WiFi Reconfiguration] Rebooting device into AP mode...");
+            EZLOG_INFO(
+                "[WiFi Reconfiguration] Rebooting device into AP mode...");
             restart();
             break;
           }
@@ -865,7 +859,4 @@ void sleepMonitorTask(void* args) {
   vTaskDelete(NULL);
 }
 
-void restart() {
-  AdvancedLogger::end();
-  ESP.restart();
-}
+void restart() { ESP.restart(); }


### PR DESCRIPTION
EzLog implemented in https://github.com/California-Strawberry-Commission/oas-data-logger/pull/107

This PR just switches over from AdvancedLogger to EzLog.

Main advantages over AdvancedLogger:
- Completely thread-safe
- Minimal stack allocation on callsites
- More control over LittleFS flushing
- Sinks (Serial and LittleFS) can be added independently. If we do not want to log to LittleFS, EzLog does not do any setup related to LittleFS (unlike AdvancedLogger)
- Cleaner API