### PR TITLE
[data-viz] Secure firmware endpoint for provisioned devices only

### DIFF
--- a/software/data-visualizer/lib/verifydevice.ts
+++ b/software/data-visualizer/lib/verifydevice.ts
@@ -27,7 +27,7 @@ import crypto from "crypto";
 export async function verifyDeviceSignature(
   deviceId: string,
   headers: Headers,
-  payloadToVerify: string,
+  payloadToVerify?: string,
 ): Promise<{ success: boolean; message?: string }> {
   // First try dev bypass
   const bypass = checkDevBypass(headers);
@@ -70,7 +70,7 @@ export async function verifyDeviceSignature(
 
   const payloadHash = crypto
     .createHash("sha256")
-    .update(payloadToVerify)
+    .update(payloadToVerify ?? "")
     .digest("hex");
 
   const stringToSign = `${deviceId}:${timestamp}:${nonce}:${payloadHash}`;

--- a/software/dlflib/include/dlflib/auth/request_signer.h
+++ b/software/dlflib/include/dlflib/auth/request_signer.h
@@ -1,12 +1,16 @@
 #pragma once
 
 #include <Arduino.h>
+#include <HTTPClient.h>
 #include <WiFiClient.h>
+
+namespace dlf::auth {
 
 class RequestSigner {
  public:
   RequestSigner(const String& deviceId, const String& secret);
-  bool writeAuthHeaders(WiFiClient& client, const String& payload);
+  bool writeAuthHeaders(WiFiClient& client, const String& payload = "");
+  bool writeAuthHeaders(HTTPClient& client, const String& payload = "");
 
  private:
   String deviceId_;
@@ -15,3 +19,5 @@ class RequestSigner {
   String sha256(const String& data);
   String hmacSha256(const String& key, const String& payload);
 };
+
+}  // namespace dlf::auth

--- a/software/dlflib/include/dlflib/components/uploader_component.h
+++ b/software/dlflib/include/dlflib/components/uploader_component.h
@@ -43,7 +43,7 @@ class UploaderComponent : public DlfComponent {
   void onWifiDisconnected(arduino_event_id_t event, arduino_event_info_t info);
   void onWifiConnected(arduino_event_id_t event, arduino_event_info_t info);
 
-  RequestSigner signer_;
+  dlf::auth::RequestSigner signer_;
   fs::FS& fs_;
   String dir_;
   String endpoint_;

--- a/software/oas-logger/lib/ota_updater/include/ota_updater/ota_updater.h
+++ b/software/oas-logger/lib/ota_updater/include/ota_updater/ota_updater.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include <dlflib/auth/request_signer.h>
 
 namespace ota {
 
@@ -23,6 +24,8 @@ class OtaUpdater {
     String deviceType;            // "V0" or "V1"
     String channel;               // "STABLE" or "BETA"
     int currentBuildNumber = -1;  // currently installed build number
+    String deviceId;
+    String deviceSecret;
 
     uint32_t manifestTimeoutMs = 3000;
     uint32_t firmwareTimeoutMs = 20000;
@@ -73,6 +76,7 @@ class OtaUpdater {
 
  private:
   Config config_;
+  dlf::auth::RequestSigner signer_;
 
   String getManifestUrl() const;
   String getFirmwareUrl(int buildNumber) const;

--- a/software/oas-logger/src/app_v0/main.cpp
+++ b/software/oas-logger/src/app_v0/main.cpp
@@ -472,9 +472,13 @@ void handleOtaUpdate() {
     otaConfig.deviceType = DEVICE_TYPE;
     otaConfig.channel = OTA_CHANNEL;
     otaConfig.currentBuildNumber = FW_BUILD_NUMBER;
+    otaConfig.deviceId = getDeviceUid();
+    otaConfig.deviceSecret = deviceSecret;
     ota::OtaUpdater otaUpdater(otaConfig);
     auto res{otaUpdater.updateIfAvailable(true)};
-    if (!res.ok) {
+    if (res.ok) {
+      EZLOG_INFO("[OTA] Success: %s", res.message.c_str());
+    } else {
       EZLOG_ERROR("[OTA] Error when updating firmware: %s",
                   res.message.c_str());
     }

--- a/software/oas-logger/src/app_v1/main.cpp
+++ b/software/oas-logger/src/app_v1/main.cpp
@@ -479,9 +479,13 @@ void handleOtaUpdate() {
   otaConfig.deviceType = DEVICE_TYPE;
   otaConfig.channel = OTA_CHANNEL;
   otaConfig.currentBuildNumber = FW_BUILD_NUMBER;
+  otaConfig.deviceId = getDeviceUid();
+  otaConfig.deviceSecret = deviceSecret;
   ota::OtaUpdater otaUpdater(otaConfig);
   auto res{otaUpdater.updateIfAvailable(true)};
-  if (!res.ok) {
+  if (res.ok) {
+    EZLOG_INFO("[OTA] Success: %s", res.message.c_str());
+  } else {
     EZLOG_ERROR("[OTA] Error when updating firmware: %s", res.message.c_str());
   }
 


### PR DESCRIPTION
- Makes signing payload optional
- Secures api/ota/manifest and api/ota/firmware the same way as api/upload. Device-side uses the same request signer as dlflib's uploader