### PR TITLE
[data-visualizer][provision-device] Improve provision-device.ts to push secrets to multiple DB environments, modify DeviceAuth to accomodate this improvement.

### DIFF
--- a/software/data-visualizer/scripts/provision-device.ts
+++ b/software/data-visualizer/scripts/provision-device.ts
@@ -419,7 +419,6 @@ async function main() {
         }
 
         if (cleanLine.includes("PROV_FAIL")) {
-          console.error("FAILURE: Device rejected the secret.");
           reject(new Error("Device reported provisioning failure"));
         }
       });

--- a/software/data-visualizer/scripts/provision-device.ts
+++ b/software/data-visualizer/scripts/provision-device.ts
@@ -14,43 +14,48 @@ import { encryptSecret } from "@/lib/crypto";
  * MODES:
  * 1. Interactive (Default): Connects via Serial (USB), waits for the device to announce
  * its ID, generates a secret, saves it to the DB, and flashes it to the device.
- * 2. Manual (--db-only): Manually inserts a known device ID and secret into the database
- * without requiring a physical device connection.
+ * 2. DB Upsert (--db-only): Connects via Serial (USB) to an already provisioned device,
+ * requests its existing ID and secret from NVS, verifies ID against passed --id value,
+ * upserts the existing secret into the passed --env(s).
  *
  * CLI ARGUMENTS:
- * @param {string} [port]   - The serial port path (e.g. /dev/ttyUSB0). Required for interactive mode.
- * @param {string} --env    - The environment config to load (local, preview, prod). Defaults to 'local'.
- * @param {flag}   --db-only - If present, skips serial connection and performs a direct DB update.
- * @param {string} --id     - The Device ID (Required for --db-only mode).
- * @param {string} --secret - The 32-byte Hex Secret (Required for --db-only mode).
+ * @param {string} [port]   - The serial port path (e.g. /dev/ttyUSB0). Required for both modes.
+ * @param {string[]} --env    - The environment configs to load (local, preview, prod). Defaults to ['local'].
+ * @param {flag}   --db-only - If present, pulls existing secret from device, performs a direct DB update.
+ * @param {string} --id     - Expected device ID (Required for --db-only mode).
  *
  * USAGE EXAMPLES:
+ * Interactive Provisioning:
+ * npm run provision-device -- /dev/ttyUSB0
  * npm run provision-device -- /dev/ttyUSB0 --env=local
- * npm run provision-device -- --db-only --id=device_123 --secret=abc...123 --env=prod
+ * npm run provision-device -- /dev/ttyUSB0 --env=local --env=preview --env=prod
+ *
+ * DB-only
+ * npm run provision-device -- /dev/ttyUSB0 --db-only --id=device_123 --env=prod
+ * npm run provision-device -- /dev/ttyUSB0 --db-only --id=device_123 --env=preview --env=prod
  */
 
 //#region Types
 
 type EnvName = "local" | "preview" | "prod";
 
+type DeviceCredentials = {
+  deviceId: string;
+  secret: string;
+};
+
 //#endregion
 
 //#region CLI Args
 
 const {
-  values: {
-    env: envRaw,
-    "db-only": dbOnly,
-    id: manualId,
-    secret: manualSecret,
-  },
+  values: { env: envRaw, "db-only": dbOnly, id: expectedDeviceId },
   positionals,
 } = parseArgs({
   options: {
-    env: { type: "string", default: "local" },
+    env: { type: "string", multiple: true, default: ["local"] },
     "db-only": { type: "boolean", default: false },
     id: { type: "string" },
-    secret: { type: "string" },
   },
   allowPositionals: true, // Allows for serialport to be captured
 });
@@ -62,13 +67,18 @@ function isEnvName(x: string): x is EnvName {
   return x === "local" || x === "preview" || x === "prod";
 }
 
-if (!isEnvName(envRaw)) {
-  console.error(
-    `Error: --env must be one of local|preview|prod (got: ${envRaw})`,
-  );
-  process.exit(1);
+const parsedEnvs = envRaw as string[];
+
+for (const env of parsedEnvs) {
+  if (!isEnvName(env)) {
+    console.error(
+      `Error: --env must be one of local|preview|prod (got: ${env})`,
+    );
+    process.exit(1);
+  }
 }
-const env: EnvName = envRaw;
+
+const targetEnvs: EnvName[] = parsedEnvs as EnvName[];
 
 //#endregion
 
@@ -124,8 +134,12 @@ async function closeSerialPort(port: SerialPort) {
   });
 }
 
+function isValidSecret(secret: string): boolean {
+  return /^[0-9a-fA-F]{64}$/.test(secret);
+}
+
 function generateSecret(): string {
-  return nodeCrypto.randomBytes(32).toString("hex"); // 32 hex chars
+  return nodeCrypto.randomBytes(32).toString("hex"); // 64 hex chars
 }
 
 async function registerDeviceInDB(
@@ -158,34 +172,157 @@ async function registerDeviceInDB(
   console.log("[DB] Update successful.");
 }
 
-async function main() {
-  // Resolve .env file relative to this script file
+async function registerDeviceInEnvs(
+  envs: EnvName[],
+  deviceId: string,
+  rawSecret: string,
+) {
   const scriptDirname = path.dirname(fileURLToPath(import.meta.url));
-  dotenv({
-    path: path.resolve(scriptDirname, `../.env.${env}`),
+
+  for (const env of envs) {
+    dotenv({
+      path: path.resolve(scriptDirname, `../.env.${env}`),
+      override: true,
+    });
+
+    const databaseUrl = requireEnv("DATABASE_URL");
+    const prisma = createPrismaClient(databaseUrl);
+
+    try {
+      console.log(`[DB:${env}] Registering device ${deviceId}...`);
+      await registerDeviceInDB(prisma, deviceId, rawSecret);
+    } finally {
+      await prisma.$disconnect();
+    }
+  }
+}
+
+async function readProvisionedDeviceCredentials(
+  portPath: string,
+): Promise<DeviceCredentials> {
+  const port = new SerialPort({
+    path: portPath,
+    baudRate: BAUD_RATE,
+    autoOpen: false,
   });
 
-  const databaseUrl = requireEnv("DATABASE_URL");
+  const parser = port.pipe(new ReadlineParser({ delimiter: "\n" }));
 
-  const prisma = createPrismaClient(databaseUrl);
+  let deviceId: string | undefined;
+  let secret: string | undefined;
+  let requestInterval: NodeJS.Timeout | undefined;
 
+  try {
+    await openSerialPort(port);
+
+    const credentialsTask = new Promise<DeviceCredentials>(
+      (resolve, reject) => {
+        parser.on("data", (line) => {
+          const cleanLine = line.toString().trim();
+
+          if (cleanLine.startsWith("DEVICE_ID:")) {
+            deviceId = cleanLine.split(":")[1]?.trim();
+          }
+
+          if (cleanLine.startsWith("PROV_SECRET:")) {
+            secret = cleanLine.split(":")[1]?.trim();
+          }
+
+          if (deviceId && secret) {
+            if (!isValidSecret(secret)) {
+              reject(
+                new Error(
+                  "Invalid secret format. Must be a 32-byte hex string (64 chars).",
+                ),
+              );
+              return;
+            }
+            resolve({ deviceId, secret });
+          }
+        });
+
+        port.write("PROV_GET\n", (err) => {
+          if (err) {
+            reject(err);
+          }
+        });
+
+        requestInterval = setInterval(() => {
+          port.write("PROV_GET\n", (err) => {
+            if (err) {
+              reject(err);
+            }
+          });
+        }, 500);
+      },
+    );
+
+    return await withTimeout(
+      credentialsTask,
+      7000,
+      "Timeout: Device did not return provisioned credentials.",
+    );
+  } finally {
+    if (requestInterval) {
+      clearInterval(requestInterval);
+    }
+
+    parser.removeAllListeners("data");
+    port.removeAllListeners();
+
+    if (port.isOpen) {
+      await closeSerialPort(port);
+    }
+  }
+}
+
+function printUsage() {
+  console.error(
+    "\nUsage:\n" +
+      "  npm run provision-device -- /dev/ttyXXX [--env=local] [--env=preview] [--env=prod]\n" +
+      "  npm run provision-device -- /dev/ttyXX --db-only --id=<deviceId> [--env=local] [--env=preview] [--env=prod]\n\n" +
+      "Notes:\n" +
+      "  --env may be repeated. Allowed values: local, preview, prod. Defaults to local.\n" +
+      "  Repeating --env writes the same device secret to each selected database environment.\n\n" +
+      "Examples:\n" +
+      "  npm run provision-device -- /dev/ttyUSB0\n" +
+      "  npm run provision-device -- /dev/ttyUSB0 --env=local\n" +
+      "  npm run provision-device -- /dev/ttyUSB0 --env=local --env=preview --env=prod\n" +
+      "  npm run provision-device -- /dev/ttyUSB0 --db-only --id=device_123 --env=prod\n" +
+      "  npm run provision-device -- /dev/ttyUSB0 --db-only --id=device_123 --env=preview --env=prod\n",
+  );
+}
+
+async function main() {
   let parser: ReadlineParser | undefined;
   let port: SerialPort | undefined;
   try {
     if (dbOnly) {
-      if (!manualId || !manualSecret) {
-        throw new Error("Missing --id or --secret for --db-only mode.");
+      if (!expectedDeviceId) {
+        throw new Error("Missing --id for --db-only mode.");
       }
 
-      const hex64Regex = /^[0-9a-fA-F]{64}$/;
-      if (!hex64Regex.test(manualSecret)) {
+      if (!portPath) {
+        throw new Error("Missing serial port for --db-only mode.");
+      }
+
+      console.log(
+        `[Mode] DB Upsert from Provisioned Device (${targetEnvs.join(", ")})`,
+      );
+
+      const credentials = await readProvisionedDeviceCredentials(portPath);
+
+      if (expectedDeviceId !== credentials.deviceId) {
         throw new Error(
-          "Invalid secret format. Must be a 32-byte hex string (64 chars).",
+          `Device ID mismatch. Provided ${expectedDeviceId}, but device gave ${credentials.deviceId}.`,
         );
       }
 
-      console.log(`[Mode] Manual DB Update (${env})`);
-      await registerDeviceInDB(prisma, manualId, manualSecret);
+      await registerDeviceInEnvs(
+        targetEnvs,
+        credentials.deviceId,
+        credentials.secret,
+      );
       return;
     }
 
@@ -214,10 +351,7 @@ async function main() {
         }
       }
 
-      console.error(
-        "\nUsage:\n" +
-          "  npx tsx scripts/provision-device.js /dev/ttyXXX --env=local\n",
-      );
+      printUsage();
 
       process.exitCode = 1;
       return;
@@ -260,7 +394,7 @@ async function main() {
           console.log(`Generated Secret: ${secret}`);
 
           try {
-            await registerDeviceInDB(prisma, deviceId, secret);
+            await registerDeviceInEnvs(targetEnvs, deviceId, secret);
 
             console.log("Pushing secret to device...");
             await sleep(500); // Needed to allow hardware to catch up
@@ -312,8 +446,6 @@ async function main() {
         await closeSerialPort(port);
       }
     }
-
-    await prisma.$disconnect();
   }
 }
 

--- a/software/data-visualizer/scripts/provision-device.ts
+++ b/software/data-visualizer/scripts/provision-device.ts
@@ -221,6 +221,12 @@ async function readProvisionedDeviceCredentials(
 
           if (cleanLine.startsWith("DEVICE_ID:")) {
             deviceId = cleanLine.split(":")[1]?.trim();
+            port.write("PROV_GET\n", (err) => {
+              if (err) {
+                reject(err);
+                return;
+              }
+            });
           }
 
           if (cleanLine.startsWith("PROV_SECRET:")) {
@@ -262,23 +268,7 @@ async function readProvisionedDeviceCredentials(
         // This prevents further driver issues, although on Ubuntu 22.04 and SerialPort 13.0.0 including dtr flag is safe.
         port.set({ rts: true });
         setTimeout(() => {
-          port.set({ rts: false }, (err) => {
-            port.write("PROV_GET\n", (err) => {
-              if (err) {
-                reject(err);
-                return;
-              }
-            });
-
-            requestInterval = setInterval(() => {
-              port.write("PROV_GET\n", (err) => {
-                if (err) {
-                  reject(err);
-                  return;
-                }
-              });
-            }, 500);
-          });
+          port.set({ rts: false }, (err) => {});
         }, 100);
       },
     );

--- a/software/data-visualizer/scripts/provision-device.ts
+++ b/software/data-visualizer/scripts/provision-device.ts
@@ -19,20 +19,20 @@ import { encryptSecret } from "@/lib/crypto";
  * upserts the existing secret into the passed --env(s).
  *
  * CLI ARGUMENTS:
- * @param {string} [port]   - The serial port path (e.g. /dev/ttyUSB0). Required for both modes.
+ * @param {string} [port]   - The serial port path (e.g. /dev/ttyACM0). Required for both modes.
  * @param {string[]} --env    - The environment configs to load (local, preview, prod). Defaults to ['local'].
  * @param {flag}   --db-only - If present, pulls existing secret from device, performs a direct DB update.
  * @param {string} --id     - Expected device ID (Required for --db-only mode).
  *
  * USAGE EXAMPLES:
  * Interactive Provisioning:
- * npm run provision-device -- /dev/ttyUSB0
- * npm run provision-device -- /dev/ttyUSB0 --env=local
- * npm run provision-device -- /dev/ttyUSB0 --env=local --env=preview --env=prod
+ * npm run provision-device -- /dev/ttyACM0
+ * npm run provision-device -- /dev/ttyACM0 --env=local
+ * npm run provision-device -- /dev/ttyACM0 --env=local --env=preview --env=prod
  *
  * DB-only
- * npm run provision-device -- /dev/ttyUSB0 --db-only --id=device_123 --env=prod
- * npm run provision-device -- /dev/ttyUSB0 --db-only --id=device_123 --env=preview --env=prod
+ * npm run provision-device -- /dev/ttyACM0 --db-only --id=device_123 --env=prod
+ * npm run provision-device -- /dev/ttyACM0 --db-only --id=device_123 --env=preview --env=prod
  */
 
 //#region Types
@@ -82,7 +82,6 @@ const targetEnvs: EnvName[] = parsedEnvs as EnvName[];
 
 //#endregion
 
-let isProvisioning = false;
 const BAUD_RATE = 115200;
 
 function createPrismaClient(databaseUrl: string): PrismaClient {
@@ -228,6 +227,11 @@ async function readProvisionedDeviceCredentials(
             secret = cleanLine.split(":")[1]?.trim();
           }
 
+          if (cleanLine.startsWith("PROV_FAIL:")) {
+            reject(new Error("Device reported provisioning failure"));
+            return;
+          }
+
           if (deviceId && secret) {
             if (!isValidSecret(secret)) {
               reject(
@@ -238,22 +242,44 @@ async function readProvisionedDeviceCredentials(
               return;
             }
             resolve({ deviceId, secret });
+            return;
           }
         });
 
-        port.write("PROV_GET\n", (err) => {
-          if (err) {
-            reject(err);
+        // This matches esptool.py behavior of ignoring issues raised by Linux for using set() over native USB
+        // This is required to use port.set() over ACM (native USB, which currently PCB only supports)
+
+        port.on("error", (err) => {
+          if (err.message.includes("Operation not supported, cannot set")) {
+            console.warn("Ignored Linux ACM warning.");
+          } else {
+            // Still notify for non ACM warning for call to set
+            console.error("Serial port error:", err.message);
           }
         });
 
-        requestInterval = setInterval(() => {
-          port.write("PROV_GET\n", (err) => {
-            if (err) {
-              reject(err);
-            }
+        // It is safer to omit dtr flag and let hardware keep pin at state it is (high for normal boot)
+        // This prevents further driver issues, although on Ubuntu 22.04 and SerialPort 13.0.0 including dtr flag is safe.
+        port.set({ rts: true });
+        setTimeout(() => {
+          port.set({ rts: false }, (err) => {
+            port.write("PROV_GET\n", (err) => {
+              if (err) {
+                reject(err);
+                return;
+              }
+            });
+
+            requestInterval = setInterval(() => {
+              port.write("PROV_GET\n", (err) => {
+                if (err) {
+                  reject(err);
+                  return;
+                }
+              });
+            }, 500);
           });
-        }, 500);
+        }, 100);
       },
     );
 
@@ -276,6 +302,95 @@ async function readProvisionedDeviceCredentials(
   }
 }
 
+async function firstTimeProvision(
+  portPath: string,
+  targetEnvs: EnvName[],
+): Promise<void> {
+  const port = new SerialPort({
+    path: portPath,
+    baudRate: BAUD_RATE,
+    autoOpen: false,
+  });
+
+  const parser = port.pipe(new ReadlineParser({ delimiter: "\n" }));
+
+  try {
+    await openSerialPort(port);
+    console.log("Port open. Waiting for 'DEVICE_ID:'...");
+
+    const provisioningTask = new Promise<void>((resolve, reject) => {
+      let isProvisioning = false;
+
+      parser.on("data", async (line) => {
+        const cleanLine = line.toString().trim();
+
+        if (cleanLine.startsWith("DEVICE_ID:")) {
+          if (isProvisioning) {
+            return;
+          }
+          isProvisioning = true;
+
+          const deviceId = cleanLine.split(":")[1].trim();
+          if (!deviceId) {
+            reject(new Error("Malformed DEVICE_ID line"));
+            return;
+          }
+          console.log(`\nDetected Device ID: ${deviceId}`);
+
+          const secret = generateSecret();
+          console.log(`Generated Secret: ${secret}`);
+
+          try {
+            await registerDeviceInEnvs(targetEnvs, deviceId, secret);
+
+            console.log("Pushing secret to device...");
+            await sleep(500); // Needed to allow hardware to catch up
+
+            if (!port) {
+              reject(new Error("Serial port not initialized"));
+              return;
+            }
+            port.write(`PROV_SET:${secret}\n`, (err) => {
+              if (err) {
+                reject(err);
+                return;
+              }
+            });
+          } catch (err) {
+            reject(err);
+            return;
+          }
+        }
+
+        if (cleanLine.includes("PROV_SUCCESS")) {
+          console.log("SUCCESS: Device accepted the secret.");
+          resolve();
+          return;
+        }
+
+        if (cleanLine.includes("PROV_FAIL")) {
+          reject(new Error("Device reported provisioning failure"));
+          return;
+        }
+      });
+    });
+
+    await withTimeout(
+      provisioningTask,
+      20000,
+      "Timeout: Device did not respond in 20s.",
+    );
+  } finally {
+    // cleanup, but let main handle error catch
+    parser.removeAllListeners("data");
+    port.removeAllListeners();
+
+    if (port.isOpen) {
+      await closeSerialPort(port);
+    }
+  }
+}
+
 function printUsage() {
   console.error(
     "\nUsage:\n" +
@@ -285,17 +400,15 @@ function printUsage() {
       "  --env may be repeated. Allowed values: local, preview, prod. Defaults to local.\n" +
       "  Repeating --env writes the same device secret to each selected database environment.\n\n" +
       "Examples:\n" +
-      "  npm run provision-device -- /dev/ttyUSB0\n" +
-      "  npm run provision-device -- /dev/ttyUSB0 --env=local\n" +
-      "  npm run provision-device -- /dev/ttyUSB0 --env=local --env=preview --env=prod\n" +
-      "  npm run provision-device -- /dev/ttyUSB0 --db-only --id=device_123 --env=prod\n" +
-      "  npm run provision-device -- /dev/ttyUSB0 --db-only --id=device_123 --env=preview --env=prod\n",
+      "  npm run provision-device -- /dev/ttyACM0\n" +
+      "  npm run provision-device -- /dev/ttyACM0 --env=local\n" +
+      "  npm run provision-device -- /dev/ttyACM0 --env=local --env=preview --env=prod\n" +
+      "  npm run provision-device -- /dev/ttyACM0 --db-only --id=device_123 --env=prod\n" +
+      "  npm run provision-device -- /dev/ttyACM0 --db-only --id=device_123 --env=preview --env=prod\n",
   );
 }
 
 async function main() {
-  let parser: ReadlineParser | undefined;
-  let port: SerialPort | undefined;
   try {
     if (dbOnly) {
       if (!expectedDeviceId) {
@@ -356,100 +469,13 @@ async function main() {
       process.exitCode = 1;
       return;
     }
-
     console.log(`[Mode] Interactive Serial Provisioning on ${portPath}`);
-    port = new SerialPort({
-      path: portPath,
-      baudRate: BAUD_RATE,
-      autoOpen: false,
-    });
-    parser = port.pipe(new ReadlineParser({ delimiter: "\n" }));
-
-    await openSerialPort(port);
-    console.log("Port open. Waiting for 'DEVICE_ID:'...");
-
-    const provisioningTask = new Promise<void>((resolve, reject) => {
-      if (!parser || !port) {
-        reject(new Error("Serial parser/port not initialized"));
-        return;
-      }
-
-      parser.on("data", async (line) => {
-        const cleanLine = line.toString().trim();
-
-        if (cleanLine.startsWith("DEVICE_ID:")) {
-          if (isProvisioning) {
-            return;
-          }
-          isProvisioning = true;
-
-          const deviceId = cleanLine.split(":")[1].trim();
-          if (!deviceId) {
-            reject(new Error("Malformed DEVICE_ID line"));
-            return;
-          }
-          console.log(`\nDetected Device ID: ${deviceId}`);
-
-          const secret = generateSecret();
-          console.log(`Generated Secret: ${secret}`);
-
-          try {
-            await registerDeviceInEnvs(targetEnvs, deviceId, secret);
-
-            console.log("Pushing secret to device...");
-            await sleep(500); // Needed to allow hardware to catch up
-
-            if (!port) {
-              reject(new Error("Serial port not initialized"));
-              return;
-            }
-            port.write(`PROV_SET:${secret}\n`, (err) => {
-              if (err) {
-                console.error("Write error:", err);
-              }
-            });
-          } catch (err) {
-            reject(err);
-          }
-        }
-
-        if (cleanLine.includes("PROV_SUCCESS")) {
-          console.log("SUCCESS: Device accepted the secret.");
-          resolve();
-        }
-
-        if (cleanLine.includes("PROV_FAIL")) {
-          reject(new Error("Device reported provisioning failure"));
-        }
-      });
-    });
-
-    await withTimeout(
-      provisioningTask,
-      20000,
-      "Timeout: Device did not respond in 20s.",
-    );
-    await closeSerialPort(port);
-  } catch (err: any) {
+    await firstTimeProvision(portPath, targetEnvs);
+  } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    console.error("\n[Error]", msg);
+    console.error("[ERROR]", msg);
     process.exitCode = 1;
-  } finally {
-    if (parser) {
-      parser.removeAllListeners("data");
-    }
-
-    if (port) {
-      port.removeAllListeners();
-      if (port.isOpen) {
-        await closeSerialPort(port);
-      }
-    }
   }
 }
 
-main().catch((err) => {
-  const msg = err instanceof Error ? err.message : String(err);
-  console.error("[ERROR]", msg);
-  process.exit(1);
-});
+main();

--- a/software/oas-logger/lib/provision/include/DeviceAuth.h
+++ b/software/oas-logger/lib/provision/include/DeviceAuth.h
@@ -11,18 +11,25 @@ class DeviceAuth {
  public:
   DeviceAuth(const char* deviceId);
 
-  // secretBuffer must have room for 65 bytes at minimum
-  // 64 for secret + 1 for null terminator
-  bool loadSecret(char* secretBuffer, size_t secretBufferLen);
-
-  bool awaitProvisioning(char* secretBuffer, size_t secretBufferLen);
-
   bool loadSecretOrProvision(char* secretBuffer, size_t secretBufferLen,
                              bool rebootOnProvision = true);
 
  private:
   char deviceId_[65];
 
+  // secretBuffer must have room for 65 bytes at minimum
+  // 64 for secret + 1 for null terminator
+  bool loadSecret(char* secretBuffer, size_t secretBufferLen);
+
+  bool awaitProvisioning(char* secretBuffer, size_t secretBufferLen);
+
   void saveSecret(const char* secret);
+
+  bool readSerialInput(char* input, size_t inputLen);
+
+  bool isValidSecret(const char* secret, size_t secretLen);
+
+  bool exportProvisionedSecret(const char* secretBuffer,
+                               size_t secretBufferLen);
 };
 }  // namespace device_auth

--- a/software/oas-logger/lib/provision/src/DeviceAuth.cpp
+++ b/software/oas-logger/lib/provision/src/DeviceAuth.cpp
@@ -63,6 +63,7 @@ bool DeviceAuth::isValidSecret(const char* secret, size_t secretLen) {
 
 bool DeviceAuth::exportProvisionedSecret(const char* secretBuffer,
                                          size_t secretBufferLen) {
+  Serial.printf("DEVICE_ID:%s\n", deviceId_);
   Serial.println("[Auth] Listening for PROV_GET");
   unsigned long start = millis();
 
@@ -77,7 +78,6 @@ bool DeviceAuth::exportProvisionedSecret(const char* secretBuffer,
           return false;
         }
 
-        Serial.printf("DEVICE_ID:%s\n", deviceId_);
         Serial.printf("PROV_SECRET:%s\n", secretBuffer);
         return true;
       }

--- a/software/oas-logger/lib/provision/src/DeviceAuth.cpp
+++ b/software/oas-logger/lib/provision/src/DeviceAuth.cpp
@@ -66,7 +66,7 @@ bool DeviceAuth::exportProvisionedSecret(const char* secretBuffer,
   Serial.println("[Auth] Listening for PROV_GET");
   unsigned long start = millis();
 
-  while (millis() - start < 5000) {
+  while (millis() - start < 100) {
     char input[32];
     if (readSerialInput(input, sizeof(input))) {
       if (strcmp(input, "PROV_GET") == 0) {
@@ -116,11 +116,11 @@ bool DeviceAuth::loadSecretOrProvision(char* secretBuffer,
 bool DeviceAuth::loadSecret(char* secretBuffer, size_t secretBufferLen) {
   Preferences preferences;
   preferences.begin(PREF_NAMESPACE, true);  // Read-only
-  size_t len =
-      preferences.getString(PREF_KEY_SECRET, secretBuffer, secretBufferLen);
+  preferences.getString(PREF_KEY_SECRET, secretBuffer, secretBufferLen);
   preferences.end();
 
-  return len > 0;
+  size_t secretLen = strnlen(secretBuffer, secretBufferLen);
+  return isValidSecret(secretBuffer, secretLen);
 }
 
 void DeviceAuth::saveSecret(const char* secret) {

--- a/software/oas-logger/lib/provision/src/DeviceAuth.cpp
+++ b/software/oas-logger/lib/provision/src/DeviceAuth.cpp
@@ -4,12 +4,16 @@
  * DeviceAuth.cpp
  *
  * PURPOSE:
- * Manages the persistence and initial setup of the device's security
- * credentials. This class handles:
+ * Manages the persistence, initial setup of the device's security
+ * credentials, and exporting of existing device seucrity credentials. This
+ * class handles:
  *
  * 1. Secure Storage: Reading/Writing the unique 32-byte hex secret to NVS.
  * 2. Provisioning: Implementing the handshake that pairs the device
  * with the database via the serial port.
+ * 3. Credential Export: Allows an already provisioned device to briefly expose
+ * its existing ID and secret over serial when requested by the provisioning
+ * script.
  *
  * PROVISIONING FLOW (Blocking):
  * If loadSecret() returns false on boot, the device enters a BLOCKING loop
@@ -17,6 +21,16 @@
  * 1. Device broadcasts: "DEVICE_ID:<id>" every 1s.
  * 2. Host script detects ID, generates secret, and sends: "PROV_SET:<secret>".
  * 3. Device validates, saves to NVS, and reboots/continues.
+ *
+ * PROVISIONING FLOW (Timed):
+ * If loadSecret() returns true on boot, the device briefly listens for
+ * "PROV_GET" inside exportProvisionedSecret().
+ * 1. Host script sends: "PROV_GET".
+ * 2. Device validates the stored secret.
+ * 3. Device responds with:
+ *      - "DEVICE_ID:<id>"
+ *      - "PROV_SECRET:<secret>"
+ * 4. If no request is received, boot continues without exposing secret.
  *
  * DEPENDENCIES:
  * - Preferences: For persistent storage (NVS) under the "oas_config" namespace.
@@ -28,11 +42,61 @@ DeviceAuth::DeviceAuth(const char* deviceId) {
   snprintf(deviceId_, sizeof(deviceId_), "%s", deviceId);
 }
 
+bool DeviceAuth::readSerialInput(char* input, size_t inputLen) {
+  if (!Serial.available() || inputLen == 0) {
+    return false;
+  }
+
+  size_t len = Serial.readBytesUntil('\n', input, inputLen - 1);
+  input[len] = '\0';
+
+  if (len > 0 && input[len - 1] == '\r') {
+    input[len - 1] = '\0';
+  }
+
+  return len > 0;
+}
+
+bool DeviceAuth::isValidSecret(const char* secret, size_t secretLen) {
+  return newSecretLen == 64 &&
+         strspn(newSecret, "0123456789abcdefABCDEF") == 64;
+}
+
+bool DeviceAuth::exportProvisionedSecret(const char* secretBuffer,
+                                         size_t secretBufferLen) {
+  Serial.println("[Auth] Listening for PROV_GET");
+  unsigned long start = millis();
+
+  while (millis() - start < 5000) {
+    char input[32];
+    if (readSerialInput(input, sizeof(input))) {
+      if (strcmp(input, "PROV_GET") == 0) {
+        size_t secretLen = strnlen(secretBuffer, secretBufferLen);
+
+        if (!isValidSecret(secretBuffer, secretLen)) {
+          Serial.println("PROV_FAIL: Stored secret invalid");
+          return false;
+        }
+
+        Serial.printf("DEVICE_ID:%s\n", deviceId_);
+        Serial.printf("PROV_SECRET:%s\n", secretBuffer);
+        return true;
+      }
+    }
+
+    delay(10);
+  }
+
+  return false;
+}
+
 bool DeviceAuth::loadSecretOrProvision(char* secretBuffer,
                                        size_t secretBufferLen,
                                        bool rebootOnProvision) {
   if (loadSecret(secretBuffer, secretBufferLen)) {
     Serial.println("[Auth] Device already provisioned.");
+    // Export is optional, a timeout should not block normal boot.
+    exportProvisionedSecret(secretBuffer, secretBufferLen);
     return true;
   }
 
@@ -79,24 +143,15 @@ bool DeviceAuth::awaitProvisioning(char* secretBuffer, size_t secretBufferLen) {
       Serial.printf("DEVICE_ID:%s\n", deviceId_);
     }
 
-    if (Serial.available()) {
-      char input[128];
-      size_t len = Serial.readBytesUntil('\n', input, sizeof(input) - 1);
-      input[len] = '\0';
+    char input[128];
 
-      if (len > 0 && input[len - 1] == '\r') {
-        input[len - 1] = '\0';
-      }
-
+    if (readSerialInput(input, sizeof(input))) {
       if (strncmp(input, "PROV_SET:", 9) == 0) {
         const char* newSecret =
             input + 9;  // PROV_SET: is 9 characters long, skip to secret.
         size_t newSecretLen = strlen(newSecret);
 
-        // This validates the length is 64 chars and strspn returns a count of
-        // valid chars, i.e. 64 if all are valid hex.
-        if (newSecretLen == 64 &&
-            strspn(newSecret, "0123456789abcdefABCDEF") == 64) {
+        if (isValidSecret(newSecret, newSecretLen)) {
           saveSecret(newSecret);
           Serial.println("PROV_SUCCESS");
           delay(1000);
@@ -105,10 +160,11 @@ bool DeviceAuth::awaitProvisioning(char* secretBuffer, size_t secretBufferLen) {
 
           return true;
         } else {
-          Serial.println("PROV_FAIL: Invalid Length");
+          Serial.println("PROV_FAIL: Invalid Secret");
         }
       }
     }
+
     delay(10);
   }
 }

--- a/software/oas-logger/lib/provision/src/DeviceAuth.cpp
+++ b/software/oas-logger/lib/provision/src/DeviceAuth.cpp
@@ -58,8 +58,7 @@ bool DeviceAuth::readSerialInput(char* input, size_t inputLen) {
 }
 
 bool DeviceAuth::isValidSecret(const char* secret, size_t secretLen) {
-  return newSecretLen == 64 &&
-         strspn(newSecret, "0123456789abcdefABCDEF") == 64;
+  return secretLen == 64 && strspn(secret, "0123456789abcdefABCDEF") == 64;
 }
 
 bool DeviceAuth::exportProvisionedSecret(const char* secretBuffer,


### PR DESCRIPTION
Refactored the device provisioning flow to support DB upserts from an already provisioned device into one or more selected database environments without manually entering the secret. In addition to this was improving the interactive mode to allow for multiple database environments to be passed. DeviceAuth now supports a `PROV_GET` export path that allows the host script to request the device ID and existing secret without mutating the device. The provisioning script’s `--db-only` mode now opens a serial connection, pulls the provisioned credentials, verifies the device-reported ID against the provided `--id`, and upserts the secret into each repeated `--env` target. Helper functions were added. API documentation and usage output were updated to reflect these changes. This has been tested and works as expected. Documentation, comments, and variable names could perhaps be improved with feedback. This method to obtain the secret from NVS was chosen due to the similarity in how the first time provisioning logic works and was the least complicated to implement.