### PR TITLE
[dlflib] Fix bug where calling LogFile::flush will corrupt the logfile

### DIFF
--- a/software/dlflib/src/dlf_logfile.cpp
+++ b/software/dlflib/src/dlf_logfile.cpp
@@ -60,13 +60,17 @@ void LogFile::taskFlusher(void* arg) {
           self->file_.flush();
           self->file_.close();
 
-          // Reopen in append mode
-          self->file_ = self->fs_.open(self->filename_, "a");
+          // Reopen file in read/write mode to update the header
+          // IMPORTANT: we use "r+" (read/write) mode instead of "a" (append)
+          // here because any write in append mode will always go to end of file
+          // regardless of any seeks.
+          self->file_ = self->fs_.open(self->filename_, "r+");
           if (!self->file_) {
             DLFLIB_LOG_ERROR(
                 "[LogFile][taskFlusher] ERROR: Could not reopen file after "
                 "sync!");
           } else {
+            self->file_.seek(0, SeekEnd);
             DLFLIB_LOG_INFO(
                 "[LogFile][taskFlusher] %s: SD sync complete, file reopened",
                 self->filename_);
@@ -131,7 +135,6 @@ void LogFile::taskFlusher(void* arg) {
     self->file_.flush();
     self->file_.close();
 
-    // Reopen in read-write mode (not append) so closeFile can use it
     self->file_ = self->fs_.open(self->filename_, "r+");
     if (self->file_) {
       // Seek to end so we know where data ends
@@ -141,8 +144,6 @@ void LogFile::taskFlusher(void* arg) {
           "[LogFile][taskFlusher] Final SD sync complete. Actual file size: "
           "%zu bytes",
           actualFileSize);
-
-      // Close it - closeFile will reopen for header update
       self->file_.close();
     } else {
       DLFLIB_LOG_ERROR(
@@ -314,7 +315,10 @@ void LogFile::closeFile() {
     checkFile.close();
   }
 
-  // Reopen in read/write mode to update header
+  // Reopen file in read/write mode to update the header
+  // IMPORTANT: we use "r+" (read/write) mode instead of "a" (append)
+  // here because any write in append mode will always go to end of file
+  // regardless of any seeks.
   file_ = fs_.open(filename_, "r+");
   if (!file_) {
     DLFLIB_LOG_ERROR(


### PR DESCRIPTION
Root cause:
- LogFile::taskFlusher periodically (every 60s) flushes, closes, then reopens the file in "a" mode (note that the file handle now has O_APPEND set)
- partialRunUploadTask calls run->flushLogFiles(), which calls LogFile::flush(). This is the problem: LogFile::flush() seeks to the byte offset of `tick_span` in the file header, then calls file_.write(), but since file_ is still in O_APPEND mode, the write goes to end of the file instead regardless of any file_.seek calls.

So, 8 bytes get appended to the end of the file each time the above sequence happens (every 60 seconds)