### PR TITLE
[dlflib][partial uploads] Don't finalize on chunk upload

### DIFF
--- a/software/data-visualizer/app/api/runs/[uuid]/streams/[streamId]/route.ts
+++ b/software/data-visualizer/app/api/runs/[uuid]/streams/[streamId]/route.ts
@@ -21,14 +21,16 @@ export const GET = withAuth(
     }
 
     try {
-      const run = await getRunForUser(user, uuid, { select: { id: true } });
+      const run = await getRunForUser(user, uuid, {
+        select: { id: true, isActive: true },
+      });
       if (!run) {
         // Either run doesn't exist, or user does not have access to it
         return NextResponse.json({ error: "Run not found" }, { status: 404 });
       }
 
       // Fetch DLF files from S3 and read data
-      const adapter = await getRunDlfAdapter(uuid);
+      const adapter = await getRunDlfAdapter(uuid, run.isActive);
       if (!adapter) {
         return NextResponse.json([]);
       }

--- a/software/data-visualizer/app/api/runs/[uuid]/streams/route.ts
+++ b/software/data-visualizer/app/api/runs/[uuid]/streams/route.ts
@@ -41,14 +41,16 @@ export const GET = withAuth(
     }
 
     try {
-      const run = await getRunForUser(user, uuid, { select: { id: true } });
+      const run = await getRunForUser(user, uuid, {
+        select: { id: true, isActive: true },
+      });
       if (!run) {
         // Either run doesn't exist, or user does not have access to it
         return NextResponse.json({ error: "Run not found" }, { status: 404 });
       }
 
       // Fetch DLF files from S3 and read data
-      const adapter = await getRunDlfAdapter(uuid);
+      const adapter = await getRunDlfAdapter(uuid, run.isActive);
       if (!adapter) {
         return NextResponse.json([]);
       }

--- a/software/data-visualizer/app/api/upload/[uuid]/chunk/route.ts
+++ b/software/data-visualizer/app/api/upload/[uuid]/chunk/route.ts
@@ -1,4 +1,5 @@
-import { dlfChunkS3Key } from "@/lib/dlf-s3";
+import { BufferAdapter, dlfChunkS3Key } from "@/lib/dlf-s3";
+import prisma from "@/lib/prisma";
 import { s3Client } from "@/lib/s3";
 import { isValidUuid } from "@/lib/utils";
 import { verifyDeviceSignature } from "@/lib/verify-device";
@@ -17,6 +18,10 @@ const ACCEPTED_FILES = new Set<string>(["meta.dlf", "event.dlf", "polled.dlf"]);
  * Required headers:
  *   x-filename: file name, such as "polled.dlf"
  *   x-chunk-number: one-based chunk number (integer)
+ *
+ * Optional headers:
+ *   x-is-active: if "true", triggers a DB upsert to keep the run record current
+ *   x-duration-s: elapsed seconds as a decimal string
  *
  * Body: raw binary (Content-Type: application/octet-stream)
  */
@@ -97,6 +102,55 @@ export async function POST(
   console.log(
     `[api/upload/chunk] Stored chunk ${chunkNumber} for ${uuid}/${filename} (${body.byteLength} bytes)`,
   );
+
+  // Keep the DB run record current.
+  // On meta.dlf chunk #1 the run record is created if it doesn't exist yet.
+  // All other chunks update isActive (and optionally durationS) if the run exists.
+  const isActive = request.headers.get("x-is-active") === "true";
+  const durationSHeader = request.headers.get("x-duration-s");
+  const durationS =
+    durationSHeader !== null ? parseFloat(durationSHeader) : undefined;
+
+  await prisma.device.upsert({
+    where: { id: deviceId },
+    update: {},
+    create: { id: deviceId },
+  });
+
+  if (filename === "meta.dlf" && chunkNumber === 1) {
+    try {
+      const metaAdapter = new BufferAdapter(Buffer.from(body), null, null);
+      const meta = await metaAdapter.getMetaDlf();
+      await prisma.run.upsert({
+        where: { uuid },
+        update: {
+          isActive,
+          ...(durationS !== undefined && { durationS }),
+        },
+        create: {
+          uuid,
+          deviceId,
+          epochTimeS: BigInt(meta.epochTimeS),
+          tickBaseUs: BigInt(meta.tickBaseUs),
+          durationS: durationS ?? 0,
+          metadata: {},
+          isActive,
+        },
+      });
+      console.log(`[api/upload/chunk] Upserted run record for ${uuid}`);
+    } catch (err) {
+      console.error(`[api/upload/chunk] Failed to upsert run ${uuid}:`, err);
+    }
+  } else {
+    // Note: we use updateMany here because it won't do anything if the run doesn't exist yet
+    await prisma.run.updateMany({
+      where: { uuid, deviceId },
+      data: {
+        isActive,
+        ...(durationS !== undefined && { durationS }),
+      },
+    });
+  }
 
   return NextResponse.json({ message: "Chunk received" }, { status: 202 });
 }

--- a/software/data-visualizer/lib/dlf-s3.ts
+++ b/software/data-visualizer/lib/dlf-s3.ts
@@ -5,7 +5,7 @@ import { Adapter } from "dlflib-js";
 /**
  * Adapter that reads DLF files from in-memory buffers fetched from S3.
  */
-class BufferAdapter extends Adapter {
+export class BufferAdapter extends Adapter {
   constructor(
     private readonly _meta: Buffer | null,
     private readonly _polled: Buffer | null,
@@ -82,18 +82,50 @@ export async function listChunkKeys(
 }
 
 /**
+ * Downloads and concatenates all stored chunks for a file into a single buffer.
+ * Returns null if no chunks exist yet.
+ */
+export async function assembleChunksToBuffer(
+  runUuid: string,
+  filename: string,
+): Promise<Buffer | null> {
+  const keys = await listChunkKeys(runUuid, filename);
+  if (keys.length === 0) {
+    return null;
+  }
+  const bufs = await Promise.all(keys.map((k) => fetchS3Object(k)));
+  return Buffer.concat(bufs.filter((b): b is Buffer => b !== null));
+}
+
+/**
  * Returns a BufferAdapter loaded with this run's DLF files from S3,
  * or null if no DLF files exist for this run.
+ *
+ * When isActive=true, assembles data directly from individual chunks.
+ * When isActive=false, reads the assembled dlf files.
  */
 export async function getRunDlfAdapter(
   runUuid: string,
+  isActive = false,
 ): Promise<BufferAdapter | null> {
+  if (isActive) {
+    const [meta, polled, event] = await Promise.all([
+      assembleChunksToBuffer(runUuid, "meta.dlf"),
+      assembleChunksToBuffer(runUuid, "polled.dlf"),
+      assembleChunksToBuffer(runUuid, "event.dlf"),
+    ]);
+    if (!meta && !polled && !event) {
+      return null;
+    }
+
+    return new BufferAdapter(meta, polled, event);
+  }
+
   const [meta, polled, event] = await Promise.all([
     fetchS3Object(dlfS3Key(runUuid, "meta.dlf")),
     fetchS3Object(dlfS3Key(runUuid, "polled.dlf")),
     fetchS3Object(dlfS3Key(runUuid, "event.dlf")),
   ]);
-
   if (!meta && !polled && !event) {
     return null;
   }

--- a/software/dlflib/include/dlflib/components/uploader_component.h
+++ b/software/dlflib/include/dlflib/components/uploader_component.h
@@ -36,6 +36,8 @@ class UploaderComponent : public Component {
     int partialRunUploadIntervalSecs = 0;
     // Enable the new chunked upload path.
     bool enableChunkedUpload = false;
+    // Read timeout per chunk POST.
+    int chunkUploadTimeoutMs = 10000;
   };
 
   /**

--- a/software/dlflib/include/dlflib/components/uploader_component.h
+++ b/software/dlflib/include/dlflib/components/uploader_component.h
@@ -81,11 +81,13 @@ class UploaderComponent : public Component {
    * @param isActive Whether the run is still actively being recorded.
    * @param finalize Whether to send the finalize request after uploading
    * chunks.
+   * @param durationS Duration of the run so far.
    * @param maxChunkSize Maximum bytes per chunk.
    * @return true on success (or if there was nothing new to upload).
    */
   bool uploadRunChunked(fs::File runDir, const char* runUuid,
-                        bool isActive = false, bool finalize = true,
+                        bool isActive = false, bool finalize = false,
+                        float durationS = 0.0f,
                         size_t maxChunkSize = 256 * 1024);
 
   /**
@@ -115,7 +117,8 @@ class UploaderComponent : public Component {
 
   // Chunked upload helpers
   bool sendChunk(HTTPClient& http, const char* runUuid, uint32_t chunkNumber,
-                 fs::File& file, size_t chunkBytes);
+                 fs::File& file, size_t chunkBytes, bool isActive,
+                 float durationS = 0.0f);
   bool sendFinalizeRequest(const char* finalizeUrl, const char* runUuid,
                            const char* const* filenames, size_t numFiles,
                            bool isActive);

--- a/software/dlflib/include/dlflib/dlf_run.h
+++ b/software/dlflib/include/dlflib/dlf_run.h
@@ -28,6 +28,10 @@ class Run {
 
   const char* uuid() const { return uuid_; }
 
+  float elapsedSecs() const {
+    return static_cast<float>(millis() - startMillis_) / 1000.0f;
+  }
+
   /**
    * Force a manual flush of log files.
    */
@@ -53,6 +57,7 @@ class Run {
   void createLogfile(dlf_stream_type_e t);
 
   char uuid_[37];
+  uint32_t startMillis_;
   fs::FS& fs_;
   char runDir_[128];
   char lockfilePath_[128];

--- a/software/dlflib/src/components/uploader_component.cpp
+++ b/software/dlflib/src/components/uploader_component.cpp
@@ -368,8 +368,11 @@ void UploaderComponent::syncTask(void* arg) {
 
       bool uploadSuccess =
           uploaderComponent->options_.enableChunkedUpload
-              ? uploaderComponent->uploadRunChunked(runDir, runDir.name())
-              : uploaderComponent->uploadRun(runDir, runDir.name());
+              ? uploaderComponent->uploadRunChunked(runDir, runDir.name(),
+                                                    /*isActive=*/false,
+                                                    /*finalize=*/true)
+              : uploaderComponent->uploadRun(runDir, runDir.name(),
+                                             /*isActive=*/false);
       if (!uploadSuccess) {
         DLFLIB_LOG_ERROR("[UploaderComponent][syncTask] Upload failed");
         runDir.close();
@@ -495,8 +498,9 @@ void UploaderComponent::partialRunUploadTask(void* arg) {
 
       bool uploadSuccess =
           uploaderComponent->options_.enableChunkedUpload
-              ? uploaderComponent->uploadRunChunked(runDir, runDir.name(),
-                                                    /*isActive=*/true)
+              ? uploaderComponent->uploadRunChunked(
+                    runDir, runDir.name(), /*isActive=*/true,
+                    /*finalize=*/false, run->elapsedSecs())
               : uploaderComponent->uploadRun(runDir, runDir.name(),
                                              /*isActive=*/true);
       if (uploadSuccess) {
@@ -599,7 +603,7 @@ bool UploaderComponent::deleteRunDir(fs::File runDir, const char* runDirPath) {
 
 bool UploaderComponent::uploadRunChunked(fs::File runDir, const char* runUuid,
                                          bool isActive, bool finalize,
-                                         size_t maxChunkSize) {
+                                         float durationS, size_t maxChunkSize) {
   if (!runDir) {
     DLFLIB_LOG_ERROR("[UploaderComponent][uploadRunChunked] No file to upload");
     return false;
@@ -715,7 +719,8 @@ bool UploaderComponent::uploadRunChunked(fs::File runDir, const char* runUuid,
       const size_t remaining = fileSize - nextByteOffset;
       const size_t chunkBytes =
           (remaining < maxChunkSize) ? remaining : maxChunkSize;
-      if (!sendChunk(httpClient, runUuid, nextChunkNum, file, chunkBytes)) {
+      if (!sendChunk(httpClient, runUuid, nextChunkNum, file, chunkBytes,
+                     isActive, durationS)) {
         file.close();
         DLFLIB_LOG_ERROR(
             "[UploaderComponent][uploadRunChunked] Chunk %u (byte %u) failed "
@@ -769,11 +774,18 @@ bool UploaderComponent::uploadRunChunked(fs::File runDir, const char* runUuid,
 
 bool UploaderComponent::sendChunk(HTTPClient& httpClient, const char* runUuid,
                                   uint32_t chunkNumber, fs::File& file,
-                                  size_t chunkBytes) {
+                                  size_t chunkBytes, bool isActive,
+                                  float durationS) {
   signer_.writeAuthHeaders(httpClient, runUuid);
   httpClient.addHeader("x-filename", file.name());
   httpClient.addHeader("x-chunk-number", String(chunkNumber));
   httpClient.addHeader("Content-Type", "application/octet-stream");
+  if (isActive) {
+    httpClient.addHeader("x-is-active", "true");
+    if (durationS > 0.0f) {
+      httpClient.addHeader("x-duration-s", String(durationS, 1));
+    }
+  }
 
   int code = httpClient.sendRequest("POST", &file, chunkBytes);
   if (code < 200 || code >= 300) {

--- a/software/dlflib/src/components/uploader_component.cpp
+++ b/software/dlflib/src/components/uploader_component.cpp
@@ -641,6 +641,7 @@ bool UploaderComponent::uploadRunChunked(fs::File runDir, const char* runUuid,
   // scope
   HTTPClientGuard httpClientGuard{httpClient};
   httpClient.setReuse(true);  // keep the TLS session alive between requests
+  httpClient.setTimeout(options_.chunkUploadTimeoutMs);
   if (!httpClient.begin(*wifiClient, chunkUrl)) {
     DLFLIB_LOG_ERROR(
         "[UploaderComponent][uploadRunChunked] HTTPClient::begin failed");

--- a/software/dlflib/src/dlf_run.cpp
+++ b/software/dlflib/src/dlf_run.cpp
@@ -13,7 +13,10 @@ Run::Run(fs::FS& fs, const char* fsDir,
          const std::vector<std::unique_ptr<dlf::datastream::AbstractStream>>&
              streams,
          std::chrono::microseconds tickInterval, const Encodable& meta)
-    : fs_(fs), streams_(streams), tickInterval_(tickInterval) {
+    : fs_(fs),
+      streams_(streams),
+      tickInterval_(tickInterval),
+      startMillis_(millis()) {
   assert(tickInterval.count() > 0);
 
   dlf::util::uuidGen(uuid_);


### PR DESCRIPTION
Currently, partial uploads trigger a finalize call every time. This results in a full dlf reassemble every partial upload, which can be very heavy for long runs (could be up to 1000 chunks given our current usage pattern), resulting in O(n^2) chunk fetches.

Instead, during partial uploads, we keep the chunks (don't finalize), and shift the reassemble cost to visualization time.

This also opens up the path to a future optimization of periodically merging chunks into one file.

## Implementation details

upload/[uuid]/chunk endpoint takes in additional headers x-is-active and x-duration-s. This is used to create/update the run metadata. So, instead of waiting until /finalize for the run metadata in the DB to be populated, we do it in /chunk.

For visualization, if the run is active, we fetch all chunks for the run from S3 instead of using the assembled dlf files. If the run is not active, we use the assembled dlf files.