### PR TITLE
[data-viz] Periodically merge chunks for active runs using partial uploads

### DIFF
--- a/software/data-visualizer/app/api/upload/[uuid]/chunk/route.ts
+++ b/software/data-visualizer/app/api/upload/[uuid]/chunk/route.ts
@@ -1,14 +1,20 @@
-import { BufferAdapter, dlfChunkS3Key } from "@/lib/dlf-s3";
+import {
+  BufferAdapter,
+  DLF_FILES,
+  dlfChunkS3Key,
+  mergeChunks,
+} from "@/lib/dlf-s3";
 import prisma from "@/lib/prisma";
 import { s3Client } from "@/lib/s3";
 import { isValidUuid } from "@/lib/utils";
 import { verifyDeviceSignature } from "@/lib/verify-device";
 import { PutObjectCommand } from "@aws-sdk/client-s3";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 
 export const dynamic = "force-dynamic";
 
-const ACCEPTED_FILES = new Set<string>(["meta.dlf", "event.dlf", "polled.dlf"]);
+const ACCEPTED_FILES = new Set<string>(DLF_FILES);
+const MERGE_CHUNK_INTERVAL = 10;
 
 /**
  * POST /api/upload/[uuid]/chunk
@@ -102,6 +108,23 @@ export async function POST(
   console.log(
     `[api/upload/chunk] Stored chunk ${chunkNumber} for ${uuid}/${filename} (${body.byteLength} bytes)`,
   );
+
+  // Compact all existing chunks for the dlf file
+  if (chunkNumber % MERGE_CHUNK_INTERVAL === 0) {
+    after(async () => {
+      try {
+        await mergeChunks(uuid, filename);
+        console.log(
+          `[api/upload/chunk] Background merge complete for run ${uuid}`,
+        );
+      } catch (err) {
+        console.error(
+          `[api/upload/chunk] Background merge failed for run ${uuid}:`,
+          err,
+        );
+      }
+    });
+  }
 
   // Keep the DB run record current.
   // On meta.dlf chunk #1 the run record is created if it doesn't exist yet.

--- a/software/data-visualizer/app/api/upload/[uuid]/finalize/route.ts
+++ b/software/data-visualizer/app/api/upload/[uuid]/finalize/route.ts
@@ -14,8 +14,6 @@ import { NextRequest, NextResponse, after } from "next/server";
 
 export const dynamic = "force-dynamic";
 
-const ACCEPTED_FILES = new Set<string>(DLF_FILES);
-
 async function withRetry<T>(
   fn: () => Promise<T>,
   {
@@ -68,13 +66,12 @@ async function computeRunDurationS(
  *
  * Triggers assembly of previously uploaded chunks and DB record creation.
  *
- * Body (JSON):
- *   {
- *     "isActive": boolean,
- *     "files": ["meta.dlf", "polled.dlf", "event.dlf"]  // files to finalize
- *   }
+ * Headers:
+ *   x-is-active: "true" if the run is still recording, omit or any other value for false.
  *
  * Returns 202 immediately; assembly + S3 upload + DB write happen in background.
+ * All three DLF files (meta.dlf, polled.dlf, event.dlf) are assembled from their
+ * chunks. Files with no chunks are silently skipped.
  */
 export async function POST(
   request: NextRequest,
@@ -109,43 +106,7 @@ export async function POST(
     );
   }
 
-  // Parse and validate request body
-  let body: { isActive?: unknown; files?: unknown };
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const isActiveRaw = body.isActive;
-  let isActive = false;
-  if (isActiveRaw !== undefined) {
-    if (typeof isActiveRaw !== "boolean") {
-      return NextResponse.json(
-        { error: "isActive must be a boolean" },
-        { status: 400 },
-      );
-    }
-    isActive = isActiveRaw;
-  }
-
-  if (!Array.isArray(body.files) || body.files.length === 0) {
-    return NextResponse.json(
-      { error: "files must be a non-empty array of filenames" },
-      { status: 400 },
-    );
-  }
-
-  const files: string[] = [];
-  for (const f of body.files) {
-    if (typeof f !== "string" || !ACCEPTED_FILES.has(f)) {
-      return NextResponse.json(
-        { error: `Unacceptable filename: ${f}` },
-        { status: 400 },
-      );
-    }
-    files.push(f);
-  }
+  const isActive = request.headers.get("x-is-active") === "true";
 
   // Check if this run already exists and upload is from the same device
   const existingRun = await prisma.run.findUnique({
@@ -162,23 +123,15 @@ export async function POST(
     );
   }
 
-  // If the run doesn't exist yet, then meta.dlf is required for the epoch time and tick base
-  if (!runExists && !files.includes("meta.dlf")) {
-    return NextResponse.json(
-      { error: "Cannot create a new run without meta.dlf" },
-      { status: 400 },
-    );
-  }
-
   console.log(
-    `[api/upload/finalize] Accepted finalize for run: ${uuid}, deviceId: ${deviceId}, isActive: ${isActive}, files: [${files.join(", ")}]`,
+    `[api/upload/finalize] Accepted finalize for run: ${uuid}, deviceId: ${deviceId}, isActive: ${isActive}`,
   );
 
   after(async () => {
     try {
-      // Assemble each DLF file from chunks into memory
+      // Assemble all DLF files from chunks into memory, skipping files with no chunks
       const fileBuffers = new Map<string, Buffer>();
-      for (const filename of files) {
+      for (const filename of DLF_FILES) {
         const buf = await assembleChunksToBuffer(uuid, filename);
         if (!buf) {
           console.warn(
@@ -195,6 +148,14 @@ export async function POST(
       if (fileBuffers.size === 0) {
         console.error(
           `[api/upload/finalize] No files assembled for run ${uuid}`,
+        );
+        return;
+      }
+
+      // If the run doesn't exist yet, then meta.dlf is required for the epoch time and tick base
+      if (!runExists && !fileBuffers.has("meta.dlf")) {
+        console.error(
+          `[api/upload/finalize] meta.dlf required to create run ${uuid}`,
         );
         return;
       }

--- a/software/data-visualizer/app/api/upload/[uuid]/finalize/route.ts
+++ b/software/data-visualizer/app/api/upload/[uuid]/finalize/route.ts
@@ -1,26 +1,20 @@
-import { dlfS3Key, listChunkKeys } from "@/lib/dlf-s3";
+import {
+  BufferAdapter,
+  DLF_FILES,
+  assembleChunksToBuffer,
+  dlfS3Key,
+  listChunkKeys,
+} from "@/lib/dlf-s3";
 import prisma from "@/lib/prisma";
 import { s3Client } from "@/lib/s3";
 import { isValidUuid } from "@/lib/utils";
 import { verifyDeviceSignature } from "@/lib/verify-device";
-import {
-  DeleteObjectsCommand,
-  GetObjectCommand,
-  PutObjectCommand,
-} from "@aws-sdk/client-s3";
-import { FSAdapter } from "dlflib-js";
-import { appendFileSync, createReadStream, mkdirSync, rmSync } from "fs";
+import { DeleteObjectsCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import { NextRequest, NextResponse, after } from "next/server";
-import { resolve } from "path";
 
 export const dynamic = "force-dynamic";
 
-const UPLOAD_DIR = "/tmp/oas/uploads";
-const ACCEPTED_FILES = new Set<string>(["meta.dlf", "event.dlf", "polled.dlf"]);
-
-function getRunUploadDir(runUuid: string) {
-  return resolve(UPLOAD_DIR, runUuid);
-}
+const ACCEPTED_FILES = new Set<string>(DLF_FILES);
 
 async function withRetry<T>(
   fn: () => Promise<T>,
@@ -35,6 +29,7 @@ async function withRetry<T>(
       return await fn();
     } catch (err) {
       lastErr = err;
+      // Delay until the next attempt
       if (attempt < maxAttempts) {
         await new Promise((res) => setTimeout(res, delayMs));
       }
@@ -43,12 +38,16 @@ async function withRetry<T>(
   throw lastErr;
 }
 
+/**
+ * Compute run duration in seconds by finding the max tick across all polled and
+ * event samples. Returns 0 if no data is present or files are unreadable.
+ */
 async function computeRunDurationS(
   polledSamples: any[],
   eventSamples: any[],
   tickBaseUs: bigint,
 ): Promise<number> {
-  let maxTick: bigint = 0n;
+  let maxTick: bigint = 0n; // sample.tick is bigint, so use bigint for maxTick to avoid precision loss
   for (const sample of polledSamples) {
     if (sample.tick > maxTick) {
       maxTick = sample.tick;
@@ -59,24 +58,9 @@ async function computeRunDurationS(
       maxTick = sample.tick;
     }
   }
-  return Number((maxTick * tickBaseUs) / 1_000_000n);
-}
 
-/**
- * Download all chunks for a file from S3 and write them sequentially to a
- * local file by appending each chunk's bytes.
- */
-async function assembleChunks(
-  chunkKeys: string[],
-  destPath: string,
-): Promise<void> {
-  for (const key of chunkKeys) {
-    const res = await s3Client.send(
-      new GetObjectCommand({ Bucket: process.env.S3_BUCKET_NAME!, Key: key }),
-    );
-    const bytes = await res.Body!.transformToByteArray();
-    appendFileSync(destPath, Buffer.from(bytes));
-  }
+  // Perform calculation with bigint to avoid precision loss
+  return Number((maxTick * tickBaseUs) / 1_000_000n);
 }
 
 /**
@@ -178,7 +162,7 @@ export async function POST(
     );
   }
 
-  // If the run doesn't exist yet, then meta.dlf is required
+  // If the run doesn't exist yet, then meta.dlf is required for the epoch time and tick base
   if (!runExists && !files.includes("meta.dlf")) {
     return NextResponse.json(
       { error: "Cannot create a new run without meta.dlf" },
@@ -191,30 +175,24 @@ export async function POST(
   );
 
   after(async () => {
-    const uploadDir = getRunUploadDir(uuid);
     try {
-      mkdirSync(uploadDir, { recursive: true });
-
-      // Assemble each DLF file from chunks
-      const assembledFiles: string[] = [];
+      // Assemble each DLF file from chunks into memory
+      const fileBuffers = new Map<string, Buffer>();
       for (const filename of files) {
-        const chunkKeys = await listChunkKeys(uuid, filename);
-        if (chunkKeys.length === 0) {
+        const buf = await assembleChunksToBuffer(uuid, filename);
+        if (!buf) {
           console.warn(
             `[api/upload/finalize] No chunks found for ${uuid}/${filename}, skipping`,
           );
           continue;
         }
-
-        const destPath = resolve(uploadDir, filename);
         console.log(
-          `[api/upload/finalize] Assembling ${chunkKeys.length} chunks for ${uuid}/${filename}`,
+          `[api/upload/finalize] Assembled chunks for ${uuid}/${filename} (${buf.byteLength} bytes)`,
         );
-        await assembleChunks(chunkKeys, destPath);
-        assembledFiles.push(filename);
+        fileBuffers.set(filename, buf);
       }
 
-      if (assembledFiles.length === 0) {
+      if (fileBuffers.size === 0) {
         console.error(
           `[api/upload/finalize] No files assembled for run ${uuid}`,
         );
@@ -228,8 +206,13 @@ export async function POST(
         create: { id: deviceId },
       });
 
+      const adapter = new BufferAdapter(
+        fileBuffers.get("meta.dlf") ?? null,
+        fileBuffers.get("polled.dlf") ?? null,
+        fileBuffers.get("event.dlf") ?? null,
+      );
+
       // Create or update run record
-      const adapter = new FSAdapter(uploadDir);
       if (!runExists) {
         const [meta, polledSamples, eventSamples] = await Promise.all([
           adapter.getMetaDlf(),
@@ -259,10 +242,7 @@ export async function POST(
         const updateData: Parameters<typeof prisma.run.update>[0]["data"] = {
           isActive,
         };
-        if (
-          assembledFiles.includes("polled.dlf") ||
-          assembledFiles.includes("event.dlf")
-        ) {
+        if (fileBuffers.has("polled.dlf") || fileBuffers.has("event.dlf")) {
           const [polledSamples, eventSamples] = await Promise.all([
             adapter.getPolledData().catch(() => []),
             adapter.getEventData().catch(() => []),
@@ -285,9 +265,8 @@ export async function POST(
       // Upload assembled files to S3
       const bucket = process.env.S3_BUCKET_NAME!;
       await Promise.all(
-        assembledFiles.map((filename) => {
+        [...fileBuffers.entries()].map(([filename, buf]) => {
           const key = dlfS3Key(uuid, filename);
-          const filePath = resolve(uploadDir, filename);
           console.log(
             `[api/upload/finalize] Uploading assembled file to S3: ${key}`,
           );
@@ -296,7 +275,7 @@ export async function POST(
               new PutObjectCommand({
                 Bucket: bucket,
                 Key: key,
-                Body: createReadStream(filePath),
+                Body: buf,
                 ContentType: "application/octet-stream",
               }),
             ),
@@ -304,19 +283,22 @@ export async function POST(
         }),
       );
 
-      // In order to support visualization of active runs (and thus partial run uploads), only
-      // delete chunk objects from S3 when finalized with isActive=false.
-      // Intermediate finalizes leave chunks in place so that future partial uploads can continue
-      // accumulating and re-assembling.
+      // Only delete chunks when the run is complete. Keep chunks for active runs
+      // so future partial uploads can continue accumulating.
       if (!isActive) {
-        for (const filename of assembledFiles) {
+        console.log(
+          `[api/upload/finalize] Run complete. Deleting all chunks for run ${uuid}`,
+        );
+        for (const filename of fileBuffers.keys()) {
           const chunkKeys = await listChunkKeys(uuid, filename);
           for (let i = 0; i < chunkKeys.length; i += 1000) {
-            const batch = chunkKeys.slice(i, i + 1000);
             await s3Client.send(
               new DeleteObjectsCommand({
                 Bucket: bucket,
-                Delete: { Objects: batch.map((Key) => ({ Key })) },
+                Delete: {
+                  Objects: chunkKeys.slice(i, i + 1000).map((Key) => ({ Key })),
+                  Quiet: true,
+                },
               }),
             );
           }
@@ -331,10 +313,6 @@ export async function POST(
         `[api/upload/finalize] Background processing failed for run ${uuid}:`,
         err,
       );
-    } finally {
-      try {
-        rmSync(uploadDir, { recursive: true, force: true });
-      } catch {}
     }
   });
 

--- a/software/data-visualizer/app/api/upload/[uuid]/route.ts
+++ b/software/data-visualizer/app/api/upload/[uuid]/route.ts
@@ -1,24 +1,14 @@
-import { dlfS3Key } from "@/lib/dlf-s3";
+import { BufferAdapter, DLF_FILES, dlfS3Key } from "@/lib/dlf-s3";
 import prisma from "@/lib/prisma";
 import { s3Client } from "@/lib/s3";
 import { isValidUuid } from "@/lib/utils";
 import { verifyDeviceSignature } from "@/lib/verify-device";
 import { PutObjectCommand } from "@aws-sdk/client-s3";
-import { FSAdapter } from "dlflib-js";
-import { createReadStream, mkdirSync, rmSync, writeFileSync } from "fs";
 import { NextRequest, NextResponse, after } from "next/server";
-import { resolve } from "path";
 
 export const dynamic = "force-dynamic";
 
-// Vercel Serverless Functions only allow writes to /tmp
-const UPLOAD_DIR = "/tmp/oas/uploads";
-
-const ACCEPTED_FILES = new Set<string>(["meta.dlf", "event.dlf", "polled.dlf"]);
-
-function getRunUploadDir(runUuid: string) {
-  return resolve(UPLOAD_DIR, runUuid);
-}
+const ACCEPTED_FILES = new Set<string>(DLF_FILES);
 
 async function withRetry<T>(
   fn: () => Promise<T>,
@@ -33,8 +23,8 @@ async function withRetry<T>(
       return await fn();
     } catch (err) {
       lastErr = err;
+      // Delay until the next attempt
       if (attempt < maxAttempts) {
-        // Delay until the next attempt
         await new Promise((res) => setTimeout(res, delayMs));
       }
     }
@@ -143,30 +133,17 @@ export async function POST(
     }
   }
 
-  // Write accepted files to local dir
-  const uploadDir = getRunUploadDir(uuid);
-  let uploadedFiles: Set<string>;
-  try {
-    mkdirSync(uploadDir, { recursive: true });
-    uploadedFiles = new Set<string>();
-    for (const file of formData.getAll("files")) {
-      if (!(file instanceof File) || !ACCEPTED_FILES.has(file.name)) {
-        continue;
-      }
-      writeFileSync(
-        resolve(uploadDir, file.name),
-        Buffer.from(await file.arrayBuffer()),
-      );
-      uploadedFiles.add(file.name);
+  // Read accepted files into memory
+  const fileBuffers = new Map<string, Buffer>();
+  for (const file of formData.getAll("files")) {
+    if (!(file instanceof File) || !ACCEPTED_FILES.has(file.name)) {
+      continue;
     }
-  } catch (err) {
-    rmSync(uploadDir, { recursive: true, force: true });
-    throw err;
+    fileBuffers.set(file.name, Buffer.from(await file.arrayBuffer()));
   }
 
-  // New runs require meta.dlf to read epoch time and tick base
-  if (!runExists && !uploadedFiles.has("meta.dlf")) {
-    rmSync(uploadDir, { recursive: true, force: true });
+  // If the run doesn't exist yet, then meta.dlf is required for the epoch time and tick base
+  if (!runExists && !fileBuffers.has("meta.dlf")) {
     return NextResponse.json(
       { error: "Cannot create a new run without meta.dlf" },
       { status: 400 },
@@ -174,7 +151,7 @@ export async function POST(
   }
 
   console.log(
-    `[api/upload] Accepted upload for run: ${uuid}, deviceId: ${deviceId}, isActive: ${isActive}, files: [${[...uploadedFiles].join(", ")}]`,
+    `[api/upload] Accepted upload for run: ${uuid}, deviceId: ${deviceId}, isActive: ${isActive}, files: [${[...fileBuffers.keys()].join(", ")}]`,
   );
 
   // S3 uploads and DB writes happen after the response is sent
@@ -187,8 +164,13 @@ export async function POST(
         create: { id: deviceId },
       });
 
-      // Create or update run
-      const adapter = new FSAdapter(uploadDir);
+      const adapter = new BufferAdapter(
+        fileBuffers.get("meta.dlf") ?? null,
+        fileBuffers.get("polled.dlf") ?? null,
+        fileBuffers.get("event.dlf") ?? null,
+      );
+
+      // Create or update run record
       if (!runExists) {
         const [metaHeader, polledSamples, eventSamples] = await Promise.all([
           adapter.getMetaDlf(),
@@ -218,7 +200,7 @@ export async function POST(
         const updateData: Parameters<typeof prisma.run.update>[0]["data"] = {
           isActive,
         };
-        if (uploadedFiles.has("polled.dlf") || uploadedFiles.has("event.dlf")) {
+        if (fileBuffers.has("polled.dlf") || fileBuffers.has("event.dlf")) {
           const [polledSamples, eventSamples] = await Promise.all([
             adapter.getPolledData().catch(() => []),
             adapter.getEventData().catch(() => []),
@@ -241,16 +223,15 @@ export async function POST(
       // Upload DLF files to S3
       const bucket = process.env.S3_BUCKET_NAME!;
       await Promise.all(
-        [...uploadedFiles].map((filename) => {
+        [...fileBuffers.entries()].map(([filename, buf]) => {
           const key = dlfS3Key(uuid, filename);
-          const filePath = resolve(uploadDir, filename);
           console.log(`[api/upload] Uploading to S3: ${key}`);
           return withRetry(() =>
             s3Client.send(
               new PutObjectCommand({
                 Bucket: bucket,
                 Key: key,
-                Body: createReadStream(filePath),
+                Body: buf,
                 ContentType: "application/octet-stream",
               }),
             ),
@@ -266,10 +247,6 @@ export async function POST(
         `[api/upload] Background processing failed for run ${uuid}:`,
         err,
       );
-    } finally {
-      try {
-        rmSync(uploadDir, { recursive: true, force: true });
-      } catch {}
     }
   });
 

--- a/software/data-visualizer/lib/dlf-s3.ts
+++ b/software/data-visualizer/lib/dlf-s3.ts
@@ -1,6 +1,13 @@
 import { s3Client } from "@/lib/s3";
-import { GetObjectCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
+import {
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
 import { Adapter } from "dlflib-js";
+
+export const DLF_FILES = ["meta.dlf", "polled.dlf", "event.dlf"] as const;
 
 /**
  * Adapter that reads DLF files from in-memory buffers fetched from S3.
@@ -95,6 +102,56 @@ export async function assembleChunksToBuffer(
   }
   const bufs = await Promise.all(keys.map((k) => fetchS3Object(k)));
   return Buffer.concat(bufs.filter((b): b is Buffer => b !== null));
+}
+
+/**
+ * Collapses all existing chunks for each DLF file into a single chunk object
+ * (chunk 1), then deletes the now-redundant individual chunks.
+ *
+ * Note that after merging, new chunks from the device continue accumulating at
+ * their original chunk numbers, so lexicographic ordering remains correct.
+ */
+export async function mergeChunks(
+  runUuid: string,
+  filename: string,
+): Promise<void> {
+  const bucket = process.env.S3_BUCKET_NAME!;
+  const chunkKeys = await listChunkKeys(runUuid, filename);
+  if (chunkKeys.length <= 1) {
+    return;
+  }
+
+  // Fetch all S3 objects and merge into a single buffer
+  const buffers = await Promise.all(chunkKeys.map((key) => fetchS3Object(key)));
+  const mergedBuffer = Buffer.concat(
+    buffers.filter((buf): buf is Buffer => buf !== null),
+  );
+
+  // Write the S3 object as chunk 1 (overwrites existing object)
+  const mergedKey = dlfChunkS3Key(runUuid, filename, 1);
+  await s3Client.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: mergedKey,
+      Body: mergedBuffer,
+      ContentType: "application/octet-stream",
+    }),
+  );
+
+  // Delete all other chunks
+  const keysToDelete = chunkKeys.filter((key) => key !== mergedKey);
+  // There is a limit of 1000 objects per request, so we need to batch each request
+  for (let i = 0; i < keysToDelete.length; i += 1000) {
+    await s3Client.send(
+      new DeleteObjectsCommand({
+        Bucket: bucket,
+        Delete: {
+          Objects: keysToDelete.slice(i, i + 1000).map((Key) => ({ Key })),
+          Quiet: true,
+        },
+      }),
+    );
+  }
 }
 
 /**

--- a/software/dlflib/include/dlflib/components/uploader_component.h
+++ b/software/dlflib/include/dlflib/components/uploader_component.h
@@ -120,7 +120,6 @@ class UploaderComponent : public Component {
                  fs::File& file, size_t chunkBytes, bool isActive,
                  float durationS = 0.0f);
   bool sendFinalizeRequest(const char* finalizeUrl, const char* runUuid,
-                           const char* const* filenames, size_t numFiles,
                            bool isActive);
   bool loadUploadProgress(const char* progressFilePath,
                           uint32_t& metaNextChunkNum,

--- a/software/dlflib/src/components/uploader_component.cpp
+++ b/software/dlflib/src/components/uploader_component.cpp
@@ -759,8 +759,7 @@ bool UploaderComponent::uploadRunChunked(fs::File runDir, const char* runUuid,
   }
 
   // Send finalize request
-  if (!sendFinalizeRequest(finalizeUrl, runUuid, uploadedFilenames,
-                           numFilesUploaded, isActive)) {
+  if (!sendFinalizeRequest(finalizeUrl, runUuid, isActive)) {
     DLFLIB_LOG_ERROR(
         "[UploaderComponent][uploadRunChunked] Finalize request failed for %s",
         runUuid);
@@ -798,24 +797,7 @@ bool UploaderComponent::sendChunk(HTTPClient& httpClient, const char* runUuid,
 
 bool UploaderComponent::sendFinalizeRequest(const char* finalizeUrl,
                                             const char* runUuid,
-                                            const char* const* filenames,
-                                            size_t numFiles, bool isActive) {
-  // Build JSON body
-  // Example: {"isActive":false,"files":["meta.dlf","polled.dlf"]}
-  char body[256];
-  int pos = snprintf(body, sizeof(body), "{\"isActive\":%s,\"files\":[",
-                     isActive ? "true" : "false");
-  bool firstFile = true;
-  for (size_t fileIdx = 0; fileIdx < numFiles; ++fileIdx) {
-    if (filenames[fileIdx] == nullptr) {
-      continue;
-    }
-    pos += snprintf(body + pos, sizeof(body) - pos, "%s\"%s\"",
-                    firstFile ? "" : ",", filenames[fileIdx]);
-    firstFile = false;
-  }
-  snprintf(body + pos, sizeof(body) - pos, "]}");
-
+                                            bool isActive) {
   WiFiClient* wifiClient = getWiFiClient(strncmp(finalizeUrl, "https", 5) == 0);
   HTTPClient httpClient;
   HTTPClientGuard httpClientGuard{httpClient};
@@ -826,9 +808,9 @@ bool UploaderComponent::sendFinalizeRequest(const char* finalizeUrl,
   }
 
   signer_.writeAuthHeaders(httpClient, runUuid);
-  httpClient.addHeader("Content-Type", "application/json");
+  httpClient.addHeader("x-is-active", isActive ? "true" : "false");
 
-  int code = httpClient.POST(body);
+  int code = httpClient.POST("");
   if (code < 200 || code >= 300) {
     DLFLIB_LOG_ERROR(
         "[UploaderComponent][sendFinalizeRequest] Server returned %d", code);


### PR DESCRIPTION
Periodically (every 10 chunks) merge chunks so that during visualization, we don't need to fetch/read as many files. With this change, we will fetch at most 10 chunk files for each dlf file.

Also makes the following optimizations:
- Instead of writing temp files to /tmp/oas/upload when reassembling dlf files, just keep data in memory
- Remove redundant and unnecessary `files` field in finalize request body